### PR TITLE
認証画面のUI改善とアカウント削除時のプロフィール連動削除を修正

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-  has_one :profile
+  has_one :profile, dependent: :destroy
   accepts_nested_attributes_for :profile
   delegate :name, to: :profile, allow_nil: true
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,46 +1,82 @@
-<h2><%= t(".title") %></h2>
+<% content_for :title, t(".title") %>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+<div class="min-h-screen bg-gradient-to-br from-primary/10 via-base-100 to-secondary/10 flex items-center justify-center px-4 py-16">
+  <div class="card bg-base-100 shadow-md w-full max-w-md">
+    <div class="card-body gap-6">
 
-  <%= f.fields_for :profile do |profile_form| %>
-    <div class="field">
-      <p><%= profile_form.label :name %></p>
-      <p><%= profile_form.text_field :name %></p>
+      <%# タイトル %>
+      <div class="text-center">
+        <h1 class="text-2xl font-extrabold text-base-content"><%= t(".title") %></h1>
+      </div>
+
+      <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+        <%= render "devise/shared/error_messages", resource: resource %>
+
+        <%# 名前 %>
+        <%= f.fields_for :profile do |profile_form| %>
+          <div class="form-control gap-1 mb-4">
+            <%= profile_form.label :name, class: "label-text font-medium" %>
+            <%= profile_form.text_field :name, class: "input input-bordered w-full" %>
+          </div>
+        <% end %>
+
+        <%# メールアドレス %>
+        <div class="form-control gap-1 mb-4">
+          <%= f.label :email, class: "label-text font-medium" %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email",
+              class: "input input-bordered w-full" %>
+        </div>
+
+        <%# パスワード %>
+        <div class="form-control gap-1 mb-4">
+          <div class="flex items-center gap-2">
+            <%= f.label :password, class: "label-text font-medium" %>
+            <span class="text-sm text-base-content/70">（<%= t(".leave_blank") %>）</span>
+          </div>
+          <% if @minimum_password_length %>
+            <span class="text-sm text-base-content/70">（<%= @minimum_password_length %> 文字以上）</span>
+          <% end %>
+          <%= f.password_field :password, autocomplete: "new-password",
+              class: "input input-bordered w-full" %>
+        </div>
+
+        <%# パスワード確認 %>
+        <div class="form-control gap-1 mb-4">
+          <%= f.label :password_confirmation, class: "label-text font-medium" %>
+          <%= f.password_field :password_confirmation, autocomplete: "new-password",
+              class: "input input-bordered w-full" %>
+        </div>
+
+        <%# 現在のパスワード %>
+        <div class="form-control gap-1 mb-4">
+          <div class="flex items-center gap-2">
+            <%= f.label :current_password, class: "label-text font-medium" %>
+            <span class="text-sm text-base-content/70">（<%= t(".current_password_hint") %>）</span>
+          </div>
+          <%= f.password_field :current_password, autocomplete: "current-password",
+              class: "input input-bordered w-full" %>
+        </div>
+
+        <%# 更新ボタン %>
+        <%= f.submit t("helpers.submit.update"), class: "btn btn-primary w-full" %>
+
+      <% end %>
+
+      <%# アカウント削除 %>
+      <div class="divider"></div>
+      <div class="text-center">
+        <p class="text-sm text-base-content/60 mb-2"><%= t(".cancel_account") %></p>
+        <%= button_to t(".unhappy"), registration_path(resource_name),
+            data: { turbo_confirm: "本当によろしいですか？" },
+            method: :delete,
+            class: "btn btn-error btn-outline btn-sm" %>
+      </div>
+
+      <%# 戻るリンク %>
+      <div class="text-center">
+        <%= link_to t(".back"), root_path, class: "link link-hover text-sm text-base-content/60" %>
+      </div>
+
     </div>
-  <% end %>
-
-  <div class="field">
-    <p><%= f.label :email %></p>
-    <p><%= f.email_field :email, autofocus: true, autocomplete: "email" %></p>
   </div>
-
-  <div class="field">
-    <p><%= f.label :password %> <i>(<%= t(".leave_blank") %>)</i></p>
-    <p><%= f.password_field :password, autocomplete: "new-password" %></p>
-    <% if @minimum_password_length %>
-      <p><em><%= @minimum_password_length %> 文字以上</em></p>
-    <% end %>
-  </div>
-
-  <div class="field">
-    <p><%= f.label :password_confirmation %></p>
-    <p><%= f.password_field :password_confirmation, autocomplete: "new-password" %></p>
-  </div>
-
-  <div class="field">
-    <p><%= f.label :current_password %> <i>(<%= t(".current_password_hint") %>)</i></p>
-    <p><%= f.password_field :current_password, autocomplete: "current-password" %></p>
-  </div>
-
-  <div class="actions">
-    <%= f.submit %>
-  </div>
-<% end %>
-
-<h3><%= t(".cancel_account") %></h3>
-<div>
-  <%= button_to t(".unhappy"), registration_path(resource_name), data: { turbo_confirm: "本当によろしいですか？" }, method: :delete %>
 </div>
-
-<%= link_to t(".back"), root_path %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,36 +1,61 @@
-<h2><%= t(".title") %></h2>
+<% content_for :title, t(".title") %>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+<div class="min-h-screen bg-gradient-to-br from-primary/10 via-base-100 to-secondary/10 flex items-center justify-center px-4 py-16">
+  <div class="card bg-base-100 shadow-md w-full max-w-md">
+    <div class="card-body gap-6">
 
-  <%= f.fields_for :profile do |profile_form| %>
-    <div class="field">
-      <p><%= profile_form.label :name %></p>
-      <p><%= profile_form.text_field :name %></p>
+      <%# タイトル %>
+      <div class="text-center">
+        <h1 class="text-2xl font-extrabold text-base-content"><%= t(".title") %></h1>
+      </div>
+
+      <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+        <%= render "devise/shared/error_messages", resource: resource %>
+
+        <%# 名前 %>
+        <%= f.fields_for :profile do |profile_form| %>
+          <div class="form-control gap-1 mb-4">
+            <%= profile_form.label :name, class: "label-text font-medium" %>
+            <%= profile_form.text_field :name,
+                class: "input input-bordered w-full" %>
+          </div>
+        <% end %>
+
+        <%# メールアドレス %>
+        <div class="form-control gap-1 mb-4">
+          <%= f.label :email, class: "label-text font-medium" %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email",
+              class: "input input-bordered w-full" %>
+        </div>
+
+        <%# パスワード %>
+        <div class="form-control gap-1 mb-4">
+          <div class="flex items-center gap-2">
+            <%= f.label :password, class: "label-text font-medium" %>
+            <% if @minimum_password_length %>
+              <span class="text-sm text-base-content/70">（<%= @minimum_password_length %> 文字以上）</span>
+            <% end %>
+          </div>
+          <%= f.password_field :password, autocomplete: "new-password",
+              class: "input input-bordered w-full" %>
+        </div>
+        <%# パスワード確認 %>
+        <div class="form-control gap-1 mb-4">
+          <%= f.label :password_confirmation, class: "label-text font-medium" %>
+          <%= f.password_field :password_confirmation, autocomplete: "new-password",
+              class: "input input-bordered w-full" %>
+        </div>
+
+        <%# 登録ボタン %>
+        <%= f.submit t("helpers.submit.create"), class: "btn btn-primary w-full" %>
+
+      <% end %>
+
+      <%# リンク %>
+      <div class="text-center text-sm text-base-content/60 flex flex-col gap-2">
+        <%= render "devise/shared/links" %>
+      </div>
+
     </div>
-  <% end %>
-
-  <div class="field">
-    <p><%= f.label :email %></p>
-    <p><%= f.email_field :email, autofocus: true, autocomplete: "email" %></p>
   </div>
-
-  <div class="field">
-    <p><%= f.label :password %></p>
-    <% if @minimum_password_length %>
-      <p><em>(<%= @minimum_password_length %> 文字以上)</em></p>
-    <% end %>
-    <p><%= f.password_field :password, autocomplete: "new-password" %></p>
-  </div>
-
-  <div class="field">
-    <p><%= f.label :password_confirmation %></p>
-    <p><%= f.password_field :password_confirmation, autocomplete: "new-password" %></p>
-  </div>
-
-  <div class="actions">
-    <%= f.submit %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,26 +1,48 @@
-<h2><%= t(".title") %></h2>
+<% content_for :title, t(".title") %>
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field">
-    <p><%= f.label :email %></p>
-    <p><%= f.email_field :email, autofocus: true, autocomplete: "email" %></p>
-  </div>
+<div class="min-h-screen bg-gradient-to-br from-primary/10 via-base-100 to-secondary/10 flex items-center justify-center px-4 py-16">
+  <div class="card bg-base-100 shadow-md w-full max-w-md">
+    <div class="card-body gap-6">
 
-  <div class="field">
-    <p><%= f.label :password %></p>
-    <p><%= f.password_field :password, autocomplete: "current-password" %></p>
-  </div>
+      <%# タイトル %>
+      <div class="text-center">
+        <h1 class="text-2xl font-extrabold text-base-content"><%= t(".title") %></h1>
+      </div>
 
-  <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <p><%= f.check_box :remember_me %></p>
-      <p><%= f.label :remember_me %></p>
+      <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+
+        <%# メールアドレス %>
+        <div class="form-control gap-1 mb-4">
+          <%= f.label :email, class: "label-text font-medium" %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email",
+              class: "input input-bordered w-full" %>
+        </div>
+
+        <%# パスワード %>
+        <div class="form-control gap-1 mb-4">
+          <%= f.label :password, class: "label-text font-medium" %>
+          <%= f.password_field :password, autocomplete: "current-password",
+              class: "input input-bordered w-full" %>
+        </div>
+
+        <%# ログインを記憶する %>
+        <% if devise_mapping.rememberable? %>
+          <div class="flex items-center gap-2 mb-4">
+            <%= f.check_box :remember_me, class: "checkbox checkbox-primary checkbox-sm" %>
+            <%= f.label :remember_me, class: "label-text" %>
+          </div>
+        <% end %>
+
+        <%# ログインボタン %>
+        <%= f.submit t("devise.sessions.new.sign_in"), class: "btn btn-primary w-full" %>
+
+      <% end %>
+
+      <%# リンク %>
+      <div class="text-center text-sm text-base-content/60 flex flex-col gap-2">
+        <%= render "devise/shared/links" %>
+      </div>
+
     </div>
-  <% end %>
-
-  <div class="actions">
-    <%= f.submit t("devise.sessions.new.sign_in") %>
   </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>


### PR DESCRIPTION
## 概要
認証画面（ログイン・新規登録・アカウント設定）のUIをDaisyUIで整備した。
またアカウント削除時にプロフィールも連動削除されるよう修正した。

## 作業内容
- ログイン画面（`devise/sessions/new.html.erb`）をDaisyUIで整備
- 新規登録画面（`devise/registrations/new.html.erb`）をDaisyUIで整備
- アカウント設定画面（`devise/registrations/edit.html.erb`）をDaisyUIで整備
- `User` モデルの `has_one :profile` に `dependent: :destroy` を追加
  - ユーザー削除時にプロフィールも連動削除されるよう修正

## 確認方法
- ログイン画面が整った状態で表示される
- 新規登録画面が整った状態で表示される
- アカウント設定画面が整った状態で表示される
- アカウント削除が正常に動作する

closes #60 