### PR TITLE
ゲーム画面のレイアウト修正とパスワード関連画面のUI整備

### DIFF
--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,25 +1,47 @@
-<h2><%= t(".title") %></h2>
+<% content_for :title, t(".title") %>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
-  <%= f.hidden_field :reset_password_token %>
+<div class="min-h-screen bg-gradient-to-br from-primary/10 via-base-100 to-secondary/10 flex items-center justify-center px-4 py-16">
+  <div class="card bg-base-100 shadow-md w-full max-w-md">
+    <div class="card-body gap-6">
 
-  <div class="field">
-    <p><%= f.label :password %></p>
-    <% if @minimum_password_length %>
-      <p><em>(<%= @minimum_password_length %> 文字以上)</em></p>
-    <% end %>
-    <p><%= f.password_field :password, autofocus: true, autocomplete: "new-password" %></p>
+      <%# タイトル %>
+      <div class="text-center">
+        <h1 class="text-2xl font-extrabold text-base-content"><%= t(".title") %></h1>
+      </div>
+
+      <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+        <%= render "devise/shared/error_messages", resource: resource %>
+        <%= f.hidden_field :reset_password_token %>
+
+        <%# パスワード %>
+        <div class="form-control gap-1 mb-4">
+          <div class="flex items-center gap-2">
+            <%= f.label :password, class: "label-text font-medium" %>
+            <% if @minimum_password_length %>
+              <span class="text-sm text-base-content/70">（<%= @minimum_password_length %> 文字以上）</span>
+            <% end %>
+          </div>
+          <%= f.password_field :password, autofocus: true, autocomplete: "new-password",
+              class: "input input-bordered w-full" %>
+        </div>
+
+        <%# パスワード確認 %>
+        <div class="form-control gap-1 mb-4">
+          <%= f.label :password_confirmation, class: "label-text font-medium" %>
+          <%= f.password_field :password_confirmation, autocomplete: "new-password",
+              class: "input input-bordered w-full" %>
+        </div>
+
+        <%# 更新ボタン %>
+        <%= f.submit t("helpers.submit.update"), class: "btn btn-primary w-full" %>
+
+      <% end %>
+
+      <%# リンク %>
+      <div class="text-center text-sm text-base-content/60 flex flex-col gap-2">
+        <%= render "devise/shared/links" %>
+      </div>
+
+    </div>
   </div>
-
-  <div class="field">
-    <p><%= f.label :password_confirmation %></p>
-    <p><%= f.password_field :password_confirmation, autocomplete: "new-password" %></p>
-  </div>
-
-  <div class="actions">
-    <%= f.submit %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,16 +1,34 @@
-<h2><%= t(".title") %></h2>
+<% content_for :title, t(".title") %>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+<div class="min-h-screen bg-gradient-to-br from-primary/10 via-base-100 to-secondary/10 flex items-center justify-center px-4 py-16">
+  <div class="card bg-base-100 shadow-md w-full max-w-md">
+    <div class="card-body gap-6">
 
-  <div class="field">
-    <p><%= f.label :email %></p>
-    <p><%= f.email_field :email, autofocus: true, autocomplete: "email" %></p>
+      <%# タイトル %>
+      <div class="text-center">
+        <h1 class="text-2xl font-extrabold text-base-content"><%= t(".title") %></h1>
+      </div>
+
+      <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+        <%= render "devise/shared/error_messages", resource: resource %>
+
+        <%# メールアドレス %>
+        <div class="form-control gap-1 mb-4">
+          <%= f.label :email, class: "label-text font-medium" %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email",
+              class: "input input-bordered w-full" %>
+        </div>
+
+        <%# 送信ボタン %>
+        <%= f.submit t(".submit"), class: "btn btn-primary w-full" %>
+
+      <% end %>
+
+      <%# リンク %>
+      <div class="text-center text-sm text-base-content/60 flex flex-col gap-2">
+        <%= render "devise/shared/links" %>
+      </div>
+
+    </div>
   </div>
-
-  <div class="actions">
-    <%= f.submit t(".submit") %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -1,11 +1,11 @@
 <% content_for :title, "ひらがな計算" %>
 
-<div class="min-h-screen bg-gradient-to-br from-primary/10 via-base-100 to-secondary/10 flex items-center justify-center px-4 py-16"
+<div class="min-h-screen bg-gradient-to-br from-primary/10 via-base-100 to-secondary/10 px-4"
      data-controller="game"
      data-game-answer-value="<%= @question[:answer] %>">
 
   <%# スコアとタイマー %>
-  <div class="fixed top-18 left-0 right-0 flex justify-between items-center px-6">
+  <div class="flex justify-between items-center py-4">
     <div class="badge badge-primary badge-lg gap-1">
       スコア: <span data-game-target="score">0</span>
     </div>
@@ -14,11 +14,13 @@
     </div>
   </div>
 
-  <div class="w-full">
+  <%# 問題文と選択肢 %>
+  <div class="flex flex-col items-center justify-center w-full" style="min-height: calc(100vh - 60px);">
+
     <%# 問題文 %>
-    <div class="text-center mb-12 overflow-hidden">
+    <div class="text-center mb-12 w-full">
       <p class="text-base-content/50 text-sm mb-4">答えを選んでください</p>
-      <h2 class="font-extrabold text-base-content leading-loose whitespace-nowrap text-center"
+      <h2 class="font-extrabold text-base-content leading-loose whitespace-nowrap w-full text-center"
           style="font-size: clamp(1.2rem, 5vw, 3rem);"
           data-game-target="question">
         <%= @question[:text] %> ＝ ？
@@ -26,7 +28,7 @@
     </div>
 
     <%# 4択ボタン %>
-    <div class="max-w-lg mx-auto grid grid-cols-2 gap-4" data-game-target="choices">
+    <div class="max-w-lg w-full grid grid-cols-2 gap-4" data-game-target="choices">
       <% @question[:choices].each do |choice| %>
         <button class="btn btn-outline btn-lg text-2xl font-bold h-24"
                 data-action="click->game#selectAnswer"


### PR DESCRIPTION
## 概要
ゲーム画面のレイアウト修正とパスワード関連画面のUI整備を行った。

## 作業内容
- ゲーム画面のスコア・タイマーを画面上部に固定せず通常配置に変更
- パスワードリセット画面（`devise/passwords/new.html.erb`）をDaisyUIで整備
- パスワード変更画面（`devise/passwords/edit.html.erb`）をDaisyUIで整備

## 確認方法
- ゲーム画面のスコア・タイマーが画面上部に表示される
- パスワードリセット画面が整った状態で表示される
- パスワード変更画面が整った状態で表示される

Closes #62 