### PR TITLE
ユーザー削除時エラー修正

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   has_one :profile, dependent: :destroy
+  has_many :scores, dependent: :destroy  # 追加
   accepts_nested_attributes_for :profile
   delegate :name, to: :profile, allow_nil: true
 end


### PR DESCRIPTION
## 概要
スコアデータがある状態でユーザー削除するとエラーが発生していたため修正した。

## 原因
スコアデータがある状態でのユーザー削除の動作確認が不足していた。
`scores` テーブルが `users` テーブルを参照しているため外部キー制約でエラーが発生していた。

## 対応内容
- `User` モデルに `has_many :scores, dependent: :destroy` を追加
- ユーザー削除時にスコアデータも連動削除されるよう修正

## 確認方法
- スコアデータがある状態でアカウント削除が正常に動作することを確認