### PR TITLE
feat: リクエストスペックを追加

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -70,4 +70,5 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   config.include FactoryBot::Syntax::Methods
+  config.include Devise::Test::IntegrationHelpers, type: :request
 end

--- a/spec/requests/games_spec.rb
+++ b/spec/requests/games_spec.rb
@@ -1,0 +1,72 @@
+require "rails_helper"
+
+RSpec.describe "Games", type: :request do
+  let!(:game_type) { create(:game_type, name: "hiragana_calc") }
+
+  describe "GET /games" do
+    it "200を返す" do
+      get games_path
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "GET /games/:id" do
+    it "200を返す" do
+      get game_path(game_type)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "POST /games/answer" do
+    let(:params) { { selected: "1", answer: "1" } }
+
+    it "JSONを返す" do
+      post answer_games_path, params: params
+      expect(response).to have_http_status(:ok)
+      expect(response.content_type).to include("application/json")
+    end
+
+    it "correct・score・questionキーを含む" do
+      post answer_games_path, params: params
+      json = JSON.parse(response.body)
+      expect(json).to include("correct", "score", "question")
+    end
+  end
+
+  describe "GET /games/result" do
+    context "ログイン済みの場合" do
+      let(:user) { create(:user) }
+
+      before do
+        sign_in user
+        get game_path(game_type) # session[:score]を初期化
+      end
+
+      it "200を返す" do
+        get result_games_path
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "スコアがDBに保存される" do
+        expect {
+          get result_games_path
+        }.to change(Score, :count).by(1)
+      end
+    end
+
+    context "未ログインの場合" do
+      before { get game_path(game_type) }
+
+      it "200を返す" do
+        get result_games_path
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "スコアがDBに保存されない" do
+        expect {
+          get result_games_path
+        }.not_to change(Score, :count)
+      end
+    end
+  end
+end

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+RSpec.describe "Home", type: :request do
+  describe "GET /" do
+    it "200を返す" do
+      get root_path
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/spec/requests/users/registrations_spec.rb
+++ b/spec/requests/users/registrations_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe "Users::Registrations", type: :request do
+  describe "GET /users/edit" do
+    context "未ログインの場合" do
+      it "ログインページにリダイレクトされる" do
+        get edit_user_registration_path
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "ログイン済みの場合" do
+      let(:user) { create(:user) }
+
+      before { sign_in user }
+
+      it "200を返す" do
+        get edit_user_registration_path
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end


### PR DESCRIPTION
リクエストスペックを追加する

## 変更内容
- `spec/requests/home_spec.rb` を追加
- `spec/requests/games_spec.rb` を追加
- `spec/requests/users/registrations_spec.rb` を追加
- `rails_helper.rb` に `Devise::Test::IntegrationHelpers` を追加

## テスト内容
- 各コントローラーの正常系リクエストテスト
- ログイン済み/未ログインでのスコア保存の分岐確認
- 未認証時の `/users/edit` リダイレクト確認

closes #72