### PR TITLE
feat: 色じゃんけんの問題生成ロジックを追加

### DIFF
--- a/app/assets/images/paper_blue.svg
+++ b/app/assets/images/paper_blue.svg
@@ -1,0 +1,9 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
+<svg fill="#1876cd" width="190px" height="190px" viewBox="-32 0 512 512" xmlns="http://www.w3.org/2000/svg" stroke="#1876cd" transform="rotate(180)">
+<g id="SVGRepo_bgCarrier" stroke-width="0"/>
+<g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"/>
+<g id="SVGRepo_iconCarrier">
+<path d="M408.781 128.007C386.356 127.578 368 146.36 368 168.79V256h-8V79.79c0-22.43-18.356-41.212-40.781-40.783C297.488 39.423 280 57.169 280 79v177h-8V40.79C272 18.36 253.644-.422 231.219.007 209.488.423 192 18.169 192 40v216h-8V80.79c0-22.43-18.356-41.212-40.781-40.783C121.488 40.423 104 58.169 104 80v235.992l-31.648-43.519c-12.993-17.866-38.009-21.817-55.877-8.823-17.865 12.994-21.815 38.01-8.822 55.877l125.601 172.705A48 48 0 0 0 172.073 512h197.59c22.274 0 41.622-15.324 46.724-37.006l26.508-112.66a192.011 192.011 0 0 0 5.104-43.975V168c.001-21.831-17.487-39.577-39.218-39.993z"/>
+</g>
+</svg>

--- a/app/assets/images/paper_gray.svg
+++ b/app/assets/images/paper_gray.svg
@@ -1,0 +1,9 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
+<svg fill="#6ba89f" width="190px" height="190px" viewBox="-32 0 512 512" xmlns="http://www.w3.org/2000/svg" stroke="#6ba89f" transform="rotate(0)">
+<g id="SVGRepo_bgCarrier" stroke-width="0"/>
+<g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"/>
+<g id="SVGRepo_iconCarrier">
+<path d="M408.781 128.007C386.356 127.578 368 146.36 368 168.79V256h-8V79.79c0-22.43-18.356-41.212-40.781-40.783C297.488 39.423 280 57.169 280 79v177h-8V40.79C272 18.36 253.644-.422 231.219.007 209.488.423 192 18.169 192 40v216h-8V80.79c0-22.43-18.356-41.212-40.781-40.783C121.488 40.423 104 58.169 104 80v235.992l-31.648-43.519c-12.993-17.866-38.009-21.817-55.877-8.823-17.865 12.994-21.815 38.01-8.822 55.877l125.601 172.705A48 48 0 0 0 172.073 512h197.59c22.274 0 41.622-15.324 46.724-37.006l26.508-112.66a192.011 192.011 0 0 0 5.104-43.975V168c.001-21.831-17.487-39.577-39.218-39.993z"/>
+</g>
+</svg>

--- a/app/assets/images/paper_red.svg
+++ b/app/assets/images/paper_red.svg
@@ -1,0 +1,9 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
+<svg fill="#ff0000" width="190px" height="190px" viewBox="-32 0 512 512" xmlns="http://www.w3.org/2000/svg" stroke="#ff0000" transform="rotate(180)">
+<g id="SVGRepo_bgCarrier" stroke-width="0"/>
+<g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"/>
+<g id="SVGRepo_iconCarrier">
+<path d="M408.781 128.007C386.356 127.578 368 146.36 368 168.79V256h-8V79.79c0-22.43-18.356-41.212-40.781-40.783C297.488 39.423 280 57.169 280 79v177h-8V40.79C272 18.36 253.644-.422 231.219.007 209.488.423 192 18.169 192 40v216h-8V80.79c0-22.43-18.356-41.212-40.781-40.783C121.488 40.423 104 58.169 104 80v235.992l-31.648-43.519c-12.993-17.866-38.009-21.817-55.877-8.823-17.865 12.994-21.815 38.01-8.822 55.877l125.601 172.705A48 48 0 0 0 172.073 512h197.59c22.274 0 41.622-15.324 46.724-37.006l26.508-112.66a192.011 192.011 0 0 0 5.104-43.975V168c.001-21.831-17.487-39.577-39.218-39.993z"/>
+</g>
+</svg>

--- a/app/assets/images/rock_blue.svg
+++ b/app/assets/images/rock_blue.svg
@@ -1,0 +1,9 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
+<svg fill="#1876cd" width="800px" height="800px" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" stroke="#1876cd" transform="rotate(180)">
+<g id="SVGRepo_bgCarrier" stroke-width="0"/>
+<g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"/>
+<g id="SVGRepo_iconCarrier">
+<path d="M464.8 80c-26.9-.4-48.8 21.2-48.8 48h-8V96.8c0-26.3-20.9-48.3-47.2-48.8-26.9-.4-48.8 21.2-48.8 48v32h-8V80.8c0-26.3-20.9-48.3-47.2-48.8-26.9-.4-48.8 21.2-48.8 48v48h-8V96.8c0-26.3-20.9-48.3-47.2-48.8-26.9-.4-48.8 21.2-48.8 48v136l-8-7.1v-48.1c0-26.3-20.9-48.3-47.2-48.8C21.9 127.6 0 149.2 0 176v66.4c0 27.4 11.7 53.5 32.2 71.8l111.7 99.3c10.2 9.1 16.1 22.2 16.1 35.9v6.7c0 13.3 10.7 24 24 24h240c13.3 0 24-10.7 24-24v-2.9c0-12.8 2.6-25.5 7.5-37.3l49-116.3c5-11.8 7.5-24.5 7.5-37.3V128.8c0-26.3-20.9-48.4-47.2-48.8z"/>
+</g>
+</svg>

--- a/app/assets/images/rock_gray.svg
+++ b/app/assets/images/rock_gray.svg
@@ -1,0 +1,9 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
+<svg fill="#6ba89f" width="190px" height="190px" viewBox="-51.2 -51.2 614.40 614.40" xmlns="http://www.w3.org/2000/svg" stroke="#6ba89f" transform="rotate(0)">
+<g id="SVGRepo_bgCarrier" stroke-width="0"/>
+<g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"/>
+<g id="SVGRepo_iconCarrier">
+<path d="M464.8 80c-26.9-.4-48.8 21.2-48.8 48h-8V96.8c0-26.3-20.9-48.3-47.2-48.8-26.9-.4-48.8 21.2-48.8 48v32h-8V80.8c0-26.3-20.9-48.3-47.2-48.8-26.9-.4-48.8 21.2-48.8 48v48h-8V96.8c0-26.3-20.9-48.3-47.2-48.8-26.9-.4-48.8 21.2-48.8 48v136l-8-7.1v-48.1c0-26.3-20.9-48.3-47.2-48.8C21.9 127.6 0 149.2 0 176v66.4c0 27.4 11.7 53.5 32.2 71.8l111.7 99.3c10.2 9.1 16.1 22.2 16.1 35.9v6.7c0 13.3 10.7 24 24 24h240c13.3 0 24-10.7 24-24v-2.9c0-12.8 2.6-25.5 7.5-37.3l49-116.3c5-11.8 7.5-24.5 7.5-37.3V128.8c0-26.3-20.9-48.4-47.2-48.8z"/>
+</g>
+</svg>

--- a/app/assets/images/rock_red.svg
+++ b/app/assets/images/rock_red.svg
@@ -1,0 +1,9 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
+<svg fill="#ff0000" width="190px" height="190px" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" stroke="#ff0000" transform="rotate(180)">
+<g id="SVGRepo_bgCarrier" stroke-width="0"/>
+<g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"/>
+<g id="SVGRepo_iconCarrier">
+<path d="M464.8 80c-26.9-.4-48.8 21.2-48.8 48h-8V96.8c0-26.3-20.9-48.3-47.2-48.8-26.9-.4-48.8 21.2-48.8 48v32h-8V80.8c0-26.3-20.9-48.3-47.2-48.8-26.9-.4-48.8 21.2-48.8 48v48h-8V96.8c0-26.3-20.9-48.3-47.2-48.8-26.9-.4-48.8 21.2-48.8 48v136l-8-7.1v-48.1c0-26.3-20.9-48.3-47.2-48.8C21.9 127.6 0 149.2 0 176v66.4c0 27.4 11.7 53.5 32.2 71.8l111.7 99.3c10.2 9.1 16.1 22.2 16.1 35.9v6.7c0 13.3 10.7 24 24 24h240c13.3 0 24-10.7 24-24v-2.9c0-12.8 2.6-25.5 7.5-37.3l49-116.3c5-11.8 7.5-24.5 7.5-37.3V128.8c0-26.3-20.9-48.4-47.2-48.8z"/>
+</g>
+</svg>

--- a/app/assets/images/scissors_blue.svg
+++ b/app/assets/images/scissors_blue.svg
@@ -1,0 +1,9 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
+<svg fill="#1876cd" width="190px" height="190px" viewBox="-32 0 512 512" xmlns="http://www.w3.org/2000/svg" stroke="#1876cd" transform="rotate(180)">
+<g id="SVGRepo_bgCarrier" stroke-width="0"/>
+<g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"/>
+<g id="SVGRepo_iconCarrier">
+<path d="M408 216c-22.092 0-40 17.909-40 40h-8v-32c0-22.091-17.908-40-40-40s-40 17.909-40 40v32h-8V48c0-26.51-21.49-48-48-48s-48 21.49-48 48v208h-13.572L92.688 78.449C82.994 53.774 55.134 41.63 30.461 51.324 5.787 61.017-6.356 88.877 3.337 113.551l74.765 190.342-31.09 24.872c-15.381 12.306-19.515 33.978-9.741 51.081l64 112A39.998 39.998 0 0 0 136 512h240c18.562 0 34.686-12.77 38.937-30.838l32-136A39.97 39.97 0 0 0 448 336v-80c0-22.091-17.908-40-40-40z"/>
+</g>
+</svg>

--- a/app/assets/images/scissors_gray.svg
+++ b/app/assets/images/scissors_gray.svg
@@ -1,0 +1,9 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
+<svg fill="#6ba89f" width="190px" height="190px" viewBox="-32 0 512 512" xmlns="http://www.w3.org/2000/svg" stroke="#6ba89f" transform="rotate(0)">
+<g id="SVGRepo_bgCarrier" stroke-width="0"/>
+<g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"/>
+<g id="SVGRepo_iconCarrier">
+<path d="M408 216c-22.092 0-40 17.909-40 40h-8v-32c0-22.091-17.908-40-40-40s-40 17.909-40 40v32h-8V48c0-26.51-21.49-48-48-48s-48 21.49-48 48v208h-13.572L92.688 78.449C82.994 53.774 55.134 41.63 30.461 51.324 5.787 61.017-6.356 88.877 3.337 113.551l74.765 190.342-31.09 24.872c-15.381 12.306-19.515 33.978-9.741 51.081l64 112A39.998 39.998 0 0 0 136 512h240c18.562 0 34.686-12.77 38.937-30.838l32-136A39.97 39.97 0 0 0 448 336v-80c0-22.091-17.908-40-40-40z"/>
+</g>
+</svg>

--- a/app/assets/images/scissors_red.svg
+++ b/app/assets/images/scissors_red.svg
@@ -1,0 +1,9 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
+<svg fill="#ff0000" width="190px" height="190px" viewBox="-32 0 512 512" xmlns="http://www.w3.org/2000/svg" stroke="#ff0000" transform="rotate(180)">
+<g id="SVGRepo_bgCarrier" stroke-width="0"/>
+<g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"/>
+<g id="SVGRepo_iconCarrier">
+<path d="M408 216c-22.092 0-40 17.909-40 40h-8v-32c0-22.091-17.908-40-40-40s-40 17.909-40 40v32h-8V48c0-26.51-21.49-48-48-48s-48 21.49-48 48v208h-13.572L92.688 78.449C82.994 53.774 55.134 41.63 30.461 51.324 5.787 61.017-6.356 88.877 3.337 113.551l74.765 190.342-31.09 24.872c-15.381 12.306-19.515 33.978-9.741 51.081l64 112A39.998 39.998 0 0 0 136 512h240c18.562 0 34.686-12.77 38.937-30.838l32-136A39.97 39.97 0 0 0 448 336v-80c0-22.091-17.908-40-40-40z"/>
+</g>
+</svg>

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -7,12 +7,19 @@ class GamesController < ApplicationController
   end
 
   def show
+    @game_type = GameType.find(params[:id])
     @question = QuestionGenerator.generate
     session[:score] = 0
+    session[:game_type] = @game_type.name
   end
 
   def answer
-    correct = params[:selected].to_i == params[:answer].to_i
+    game_type_name = session[:game_type]
+    correct = if game_type_name == "hiragana_calc"
+                params[:selected].to_i == params[:answer].to_i
+    else
+                params[:selected] == params[:answer]
+    end
     session[:score] = (session[:score] || 0) + 1 if correct
 
     @question = QuestionGenerator.generate
@@ -31,7 +38,7 @@ class GamesController < ApplicationController
   private
 
   def save_score
-    game_type = GameType.find_by!(name: "hiragana_calc")
+    game_type = GameType.find_by!(name: session[:game_type])
     Score.create!(
       user: current_user,
       game_type: game_type,

--- a/app/services/color_janken_generator.rb
+++ b/app/services/color_janken_generator.rb
@@ -1,0 +1,14 @@
+class ColorJankenGenerator
+  HANDS = [ "rock", "scissors", "paper" ].freeze
+  COLORS = [ "blue", "red" ].freeze
+  WINS  = { "rock" => "paper", "scissors" => "rock", "paper" => "scissors" }.freeze
+  LOSES = { "rock" => "scissors", "scissors" => "paper", "paper" => "rock" }.freeze
+
+  def self.generate
+    hand  = HANDS.sample
+    color = COLORS.sample
+    answer = color == "blue" ? WINS[hand] : LOSES[hand]
+
+    { hand: hand, color: color, answer: answer }
+  end
+end

--- a/app/views/games/index.html.erb
+++ b/app/views/games/index.html.erb
@@ -42,7 +42,7 @@
     </div>
 
     <%# スタートボタン %>
-    <%= link_to game_path(id: "hiragana_calc"), class: "btn btn-primary btn-lg w-full text-lg" do %>
+    <%= link_to game_path(@game_type), class: "btn btn-primary btn-lg w-full text-lg" do %>
       ▶ スタート
     <% end %>
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,7 +8,12 @@
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
 
-GameType.find_or_create_by!(name: 'hiragana_calc') do |game_type|
-  game_type.display_name = 'ひらがな計算'
-  game_type.description = 'ひらがなで書かれた数式を解いて脳を鍛える脳トレです。'
+[
+  { name: 'hiragana_calc', display_name: 'ひらがな計算', description: 'ひらがなで書かれた数式を解いて脳を鍛える脳トレです。' },
+  { name: 'color_janken', display_name: '色じゃんけん', description: '青い手には勝つ手を、赤い手には負ける手を出す脳トレです。' }
+].each do |attrs|
+  GameType.find_or_create_by!(name: attrs[:name]) do |game_type|
+    game_type.display_name = attrs[:display_name]
+    game_type.description = attrs[:description]
+  end
 end


### PR DESCRIPTION
色じゃんけんの問題生成ロジックを追加する

## 変更内容
- `app/assets/images/`にじゃんけん画像9枚を追加
- `app/services/color_janken_generator.rb`を作成
- `db/seeds.rb`にcolor_jankenを追加
- `GamesController`をゲームタイプに応じた処理に修正

## 実装内容
- 青い手には勝つ手、赤い手には負ける手を正解とするロジック
- GENERATORSハッシュでゲームタイプに応じたGeneratorを呼び出す
- session[:game_type]でゲームタイプを管理

closes #74