### PR TITLE
ゲームのルーティング・画面設計を整理する

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -2,13 +2,18 @@ class GamesController < ApplicationController
   include BestScoreLoadable
   before_action :set_best_score, only: [ :result ]
 
-  def index
-    @game_type = GameType.find_by!(name: "hiragana_calc")
-  end
+  GENERATORS = {
+    "hiragana_calc" => QuestionGenerator,
+    "color_janken"  => ColorJankenGenerator
+  }.freeze
 
   def show
     @game_type = GameType.find(params[:id])
-    @question = QuestionGenerator.generate
+  end
+
+  def play
+    @game_type = GameType.find(params[:id])
+    @question = GENERATORS[@game_type.name].generate
     session[:score] = 0
     session[:game_type] = @game_type.name
   end
@@ -22,7 +27,7 @@ class GamesController < ApplicationController
     end
     session[:score] = (session[:score] || 0) + 1 if correct
 
-    @question = QuestionGenerator.generate
+    @question = GENERATORS[session[:game_type]].generate
     render json: {
       correct: correct,
       score: session[:score] || 0,
@@ -32,6 +37,7 @@ class GamesController < ApplicationController
 
   def result
     @score = session[:score] || 0
+    @game_type = GameType.find_by(name: session[:game_type])
     save_score if user_signed_in?
   end
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -3,5 +3,6 @@ class HomeController < ApplicationController
   before_action :set_best_score, only: [ :index ]
 
   def index
+    @today_game = GameType.find_by(name: "hiragana_calc")
   end
 end

--- a/app/views/games/_color_janken_description.html.erb
+++ b/app/views/games/_color_janken_description.html.erb
@@ -1,0 +1,35 @@
+<div class="text-center mb-10">
+  <div class="w-20 h-20 bg-primary/10 rounded-3xl flex items-center justify-center mx-auto mb-6">
+    <span class="text-5xl">✊</span>
+  </div>
+  <h1 class="text-4xl font-extrabold text-base-content mb-2">
+    <%= @game_type.display_name %>
+  </h1>
+  <p class="text-base-content/60 text-sm">
+    <%= @game_type.description %>
+  </p>
+</div>
+
+<div class="grid grid-cols-3 gap-4 mb-10">
+  <div class="card bg-base-100 shadow-sm">
+    <div class="card-body items-center text-center p-4 gap-2">
+      <span class="text-2xl">🔵</span>
+      <p class="text-xs font-semibold text-base-content">青い手が出たら</p>
+      <p class="text-xs text-base-content/50">勝つ手を出せ</p>
+    </div>
+  </div>
+  <div class="card bg-base-100 shadow-sm">
+    <div class="card-body items-center text-center p-4 gap-2">
+      <span class="text-2xl">🔴</span>
+      <p class="text-xs font-semibold text-base-content">赤い手が出たら</p>
+      <p class="text-xs text-base-content/50">負ける手を出せ</p>
+    </div>
+  </div>
+  <div class="card bg-base-100 shadow-sm">
+    <div class="card-body items-center text-center p-4 gap-2">
+      <span class="text-2xl">⏱️</span>
+      <p class="text-xs font-semibold text-base-content">30秒で挑戦</p>
+      <p class="text-xs text-base-content/50">何問解けるか</p>
+    </div>
+  </div>
+</div>

--- a/app/views/games/_hiragana_calc_description.html.erb
+++ b/app/views/games/_hiragana_calc_description.html.erb
@@ -1,0 +1,35 @@
+<div class="text-center mb-10">
+  <div class="w-20 h-20 bg-primary/10 rounded-3xl flex items-center justify-center mx-auto mb-6">
+    <span class="text-5xl">🧮</span>
+  </div>
+  <h1 class="text-4xl font-extrabold text-base-content mb-2">
+    <%= @game_type.display_name %>
+  </h1>
+  <p class="text-base-content/60 text-sm">
+    <%= @game_type.description %>
+  </p>
+</div>
+
+<div class="grid grid-cols-3 gap-4 mb-10">
+  <div class="card bg-base-100 shadow-sm">
+    <div class="card-body items-center text-center p-4 gap-2">
+      <span class="text-2xl">📝</span>
+      <p class="text-xs font-semibold text-base-content">問題が出る</p>
+      <p class="text-xs text-base-content/50">数式が表示</p>
+    </div>
+  </div>
+  <div class="card bg-base-100 shadow-sm">
+    <div class="card-body items-center text-center p-4 gap-2">
+      <span class="text-2xl">👆</span>
+      <p class="text-xs font-semibold text-base-content">正解を選ぶ</p>
+      <p class="text-xs text-base-content/50">4択からタップ</p>
+    </div>
+  </div>
+  <div class="card bg-base-100 shadow-sm">
+    <div class="card-body items-center text-center p-4 gap-2">
+      <span class="text-2xl">⏱️</span>
+      <p class="text-xs font-semibold text-base-content">30秒で挑戦</p>
+      <p class="text-xs text-base-content/50">何問解けるか</p>
+    </div>
+  </div>
+</div>

--- a/app/views/games/play.html.erb
+++ b/app/views/games/play.html.erb
@@ -1,0 +1,41 @@
+<% content_for :title, "ひらがな計算" %>
+
+<div class="min-h-screen bg-gradient-to-br from-primary/10 via-base-100 to-secondary/10 px-4"
+     data-controller="game"
+     data-game-answer-value="<%= @question[:answer] %>">
+
+  <%# スコアとタイマー %>
+  <div class="flex justify-between items-center py-4">
+    <div class="badge badge-primary badge-lg gap-1">
+      スコア: <span data-game-target="score">0</span>
+    </div>
+    <div class="badge badge-outline badge-lg gap-1">
+      ⏱ <span data-game-target="timer">30</span> 秒
+    </div>
+  </div>
+
+  <%# 問題文と選択肢 %>
+  <div class="flex flex-col items-center justify-center w-full" style="min-height: calc(100vh - 60px);">
+
+    <%# 問題文 %>
+    <div class="text-center mb-12 w-full">
+      <p class="text-base-content/50 text-sm mb-4">答えを選んでください</p>
+      <h2 class="font-extrabold text-base-content leading-loose whitespace-nowrap w-full text-center"
+          style="font-size: clamp(1.2rem, 5vw, 3rem);"
+          data-game-target="question">
+        <%= @question[:text] %> ＝ ？
+      </h2>
+    </div>
+
+    <%# 4択ボタン %>
+    <div class="max-w-lg w-full grid grid-cols-2 gap-4" data-game-target="choices">
+      <% @question[:choices].each do |choice| %>
+        <button class="btn btn-outline btn-lg text-2xl font-bold h-24"
+                data-action="click->game#selectAnswer"
+                data-choice="<%= choice %>">
+          <%= choice %>
+        </button>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/games/result.html.erb
+++ b/app/views/games/result.html.erb
@@ -31,6 +31,6 @@
       </div>
     </div>
 
-    <%= link_to "もう一度挑戦する", games_path, class: "btn btn-primary btn-lg" %>
+    <%= link_to "もう一度挑戦する", game_path(@game_type), class: "btn btn-primary btn-lg" %>
   </div>
 </div>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -1,41 +1,13 @@
-<% content_for :title, "ひらがな計算" %>
+<% content_for :title, @game_type.display_name %>
 
-<div class="min-h-screen bg-gradient-to-br from-primary/10 via-base-100 to-secondary/10 px-4"
-     data-controller="game"
-     data-game-answer-value="<%= @question[:answer] %>">
+<div class="min-h-screen bg-gradient-to-br from-primary/10 via-base-100 to-secondary/10 flex items-center justify-center px-4 py-16">
+  <div class="max-w-lg w-full">
 
-  <%# スコアとタイマー %>
-  <div class="flex justify-between items-center py-4">
-    <div class="badge badge-primary badge-lg gap-1">
-      スコア: <span data-game-target="score">0</span>
-    </div>
-    <div class="badge badge-outline badge-lg gap-1">
-      ⏱ <span data-game-target="timer">30</span> 秒
-    </div>
-  </div>
+    <%= render "#{@game_type.name}_description" %>
 
-  <%# 問題文と選択肢 %>
-  <div class="flex flex-col items-center justify-center w-full" style="min-height: calc(100vh - 60px);">
+    <%= link_to play_game_path(@game_type), class: "btn btn-primary btn-lg w-full text-lg" do %>
+      ▶ スタート
+    <% end %>
 
-    <%# 問題文 %>
-    <div class="text-center mb-12 w-full">
-      <p class="text-base-content/50 text-sm mb-4">答えを選んでください</p>
-      <h2 class="font-extrabold text-base-content leading-loose whitespace-nowrap w-full text-center"
-          style="font-size: clamp(1.2rem, 5vw, 3rem);"
-          data-game-target="question">
-        <%= @question[:text] %> ＝ ？
-      </h2>
-    </div>
-
-    <%# 4択ボタン %>
-    <div class="max-w-lg w-full grid grid-cols-2 gap-4" data-game-target="choices">
-      <% @question[:choices].each do |choice| %>
-        <button class="btn btn-outline btn-lg text-2xl font-bold h-24"
-                data-action="click->game#selectAnswer"
-                data-choice="<%= choice %>">
-          <%= choice %>
-        </button>
-      <% end %>
-    </div>
   </div>
 </div>

--- a/app/views/home/_logged_in.html.erb
+++ b/app/views/home/_logged_in.html.erb
@@ -15,5 +15,5 @@
   </div>
 </div>
 
-  <%= link_to "プレイする", games_path, class: "btn btn-primary btn-lg" %>
+  <%= link_to "プレイする", game_path(@today_game), class: "btn btn-primary btn-lg" %>
 </div>

--- a/app/views/home/_logged_out.html.erb
+++ b/app/views/home/_logged_out.html.erb
@@ -88,7 +88,7 @@
     <p class="text-center text-base-content/50 mb-10 text-sm">あなたの脳を刺激しよう</p>
 
     <%# ゲームカード（将来的に game_types からループ） %>
-    <%= link_to games_path, class: "card bg-base-100 shadow-md hover:shadow-lg transition-shadow cursor-pointer group" do %>
+    <%= link_to game_path(@today_game), class: "card bg-base-100 shadow-md hover:shadow-lg transition-shadow cursor-pointer group" do %>
       <div class="card-body flex-row items-center gap-4">
         <div class="w-16 h-16 bg-primary/10 rounded-2xl flex items-center justify-center flex-shrink-0 group-hover:bg-primary/20 transition-colors">
           <span class="text-3xl">🧮</span>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,8 @@
 Rails.application.routes.draw do
-  resources :games, only: [ :index, :show ] do
+  resources :games, only: [ :show ] do
+    member do
+      get :play
+    end
     collection do
       post :answer
       get  :result

--- a/spec/requests/games_spec.rb
+++ b/spec/requests/games_spec.rb
@@ -3,13 +3,6 @@ require "rails_helper"
 RSpec.describe "Games", type: :request do
   let!(:game_type) { create(:game_type, name: "hiragana_calc") }
 
-  describe "GET /games" do
-    it "200を返す" do
-      get games_path
-      expect(response).to have_http_status(:ok)
-    end
-  end
-
   describe "GET /games/:id" do
     it "200を返す" do
       get game_path(game_type)
@@ -17,8 +10,16 @@ RSpec.describe "Games", type: :request do
     end
   end
 
+  describe "GET /games/:id/play" do
+    it "200を返す" do
+      get play_game_path(game_type)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
   describe "POST /games/answer" do
     let(:params) { { selected: "1", answer: "1" } }
+    before { get play_game_path(game_type) }# session[:game_type]をセットするために先にplayにアクセス
 
     it "JSONを返す" do
       post answer_games_path, params: params
@@ -39,7 +40,7 @@ RSpec.describe "Games", type: :request do
 
       before do
         sign_in user
-        get game_path(game_type) # session[:score]を初期化
+        get play_game_path(game_type) # session[:score]を初期化
       end
 
       it "200を返す" do
@@ -55,7 +56,7 @@ RSpec.describe "Games", type: :request do
     end
 
     context "未ログインの場合" do
-      before { get game_path(game_type) }
+      before { get play_game_path(game_type) }
 
       it "200を返す" do
         get result_games_path

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe "Home", type: :request do
+  let!(:game_type) { create(:game_type, name: "hiragana_calc") }
+
   describe "GET /" do
     it "200を返す" do
       get root_path


### PR DESCRIPTION
ゲームのルーティング・画面設計を整理する

## 変更内容
- `index`アクションを削除
- `show`を説明画面に変更
- `play`アクションを追加してプレイ画面にする
- ルーティングを更新
  - `/games/:id` → show（説明画面）
  - `/games/:id/play` → play（プレイ画面）
- `index.html.erb`を削除
- `show.html.erb`を説明画面用に作り直す
- `play.html.erb`を作成
- パーシャルで説明内容をゲームごとに分ける
- ホーム画面のリンクを更新

closes #111