### PR TITLE
fix: 本番環境で色じゃんけんの画像パスを修正

### DIFF
--- a/app/javascript/controllers/color_janken_controller.js
+++ b/app/javascript/controllers/color_janken_controller.js
@@ -3,16 +3,14 @@ import { Controller } from "@hotwired/stimulus"
 // Connects to data-controller="color-janken"
 export default class extends Controller {
   static targets = ["question"]
-  static values = { answer: String }
+  static values = { answer: String, images: Object  }
 
   gameQuestionUpdated(event) {
     const question = event.detail.question
-    const color = question.color
-    const hand = question.hand
-
-    this.questionTarget.src = `/assets/${hand}_${color}.svg`
+    const key = `${question.hand}_${question.color}`
+    this.questionTarget.src = this.imagesValue[key]
     this.questionTarget.previousElementSibling.textContent =
-      color === "blue" ? "勝つ手を出せ！" : "負ける手を出せ！"
+      question.color === "blue" ? "勝つ手を出せ！" : "負ける手を出せ！"
     this.answerValue = question.answer
   }
 }

--- a/app/views/games/_color_janken_play.html.erb
+++ b/app/views/games/_color_janken_play.html.erb
@@ -2,7 +2,15 @@
      style="min-height: calc(100vh - 60px);"
      data-controller="color-janken"
      data-action="game:questionUpdated@window->color-janken#gameQuestionUpdated"
-     data-color-janken-answer-value="<%= @question[:answer] %>">
+     data-color-janken-answer-value="<%= @question[:answer] %>"
+     data-color-janken-images-value="<%= {
+       'rock_blue'     => asset_path('rock_blue.svg'),
+       'rock_red'      => asset_path('rock_red.svg'),
+       'scissors_blue' => asset_path('scissors_blue.svg'),
+       'scissors_red'  => asset_path('scissors_red.svg'),
+       'paper_blue'    => asset_path('paper_blue.svg'),
+       'paper_red'     => asset_path('paper_red.svg')
+     }.to_json %>">
 
   <%# 問題画像 %>
   <div class="text-center mb-12">


### PR DESCRIPTION
本番環境で色じゃんけんの2問目以降画像が表示されない問題を修正

## 原因
JavaScriptで直接`/assets/rock_blue.svg`のパスを指定していたため、本番環境のフィンガープリント付きパスと一致しなかった

## 修正内容
- `_color_janken_play.html.erb`に画像パスをデータ属性として埋め込む
- `color_janken_controller.js`で`imagesValue`から正しいパスを参照するように変更

refs #75