### PR TITLE
ゲームタイプごとのベストスコア表示と色じゃんけんへの導線を追加

### DIFF
--- a/app/controllers/concerns/best_score_loadable.rb
+++ b/app/controllers/concerns/best_score_loadable.rb
@@ -3,7 +3,15 @@ module BestScoreLoadable
 
   def set_best_score
     if user_signed_in?
-      @best_score = Score.where(user: current_user).maximum(:score) || 0
+      scores = Score.where(user: current_user)
+                    .group(:game_type_id)
+                    .maximum(:score)
+      @best_scores = GameType.all.map do |game_type|
+        {
+          name: game_type.display_name,
+          score: scores[game_type.id] || 0
+        }
+      end
     end
   end
 end

--- a/app/views/games/result.html.erb
+++ b/app/views/games/result.html.erb
@@ -14,22 +14,23 @@
     </div>
 
     <%# ベストスコア %>
-    <div class="card bg-base-100 shadow-md mb-8">
-      <div class="card-body items-center text-center">
-        <h2 class="card-title">ベストスコア</h2>
-        <% if user_signed_in? %>
-          <p class="text-4xl font-bold text-primary"><%= @best_score %></p>
+  <div class="card bg-base-100 shadow-md mb-8">
+    <div class="card-body items-center text-center">
+      <h2 class="card-title">ベストスコア</h2>
+      <% if user_signed_in? %>
+        <% current_best = @best_scores.find { |b| b[:name] == @game_type.display_name } %>
+          <p class="text-4xl font-bold text-primary"><%= current_best[:score] %></p>
           <p class="text-sm text-base-content/50">問正解</p>
-        <% else %>
-          <p class="text-4xl font-bold text-primary">-</p>
-          <p class="text-sm text-base-content/50">ログインするとスコアが記録されます</p>
-          <div class="flex gap-2 justify-center mt-2">
-            <%= link_to "ログイン", new_user_session_path, class: "btn btn-primary btn-sm mt-2" %>
-            <%= link_to "新規登録", new_user_registration_path, class: "btn btn-outline btn-sm mt-2" %>
-          </div>
-        <% end %>
-      </div>
+      <% else %>
+        <p class="text-4xl font-bold text-primary">-</p>
+        <p class="text-sm text-base-content/50">ログインするとスコアが記録されます</p>
+        <div class="flex gap-2 justify-center mt-2">
+          <%= link_to "ログイン", new_user_session_path, class: "btn btn-primary btn-sm mt-2" %>
+          <%= link_to "新規登録", new_user_registration_path, class: "btn btn-outline btn-sm mt-2" %>
+        </div>
+      <% end %>
     </div>
+  </div>
 
     <%= link_to "もう一度挑戦する", game_path(@game_type), class: "btn btn-primary btn-lg" %>
   </div>

--- a/app/views/home/_logged_in.html.erb
+++ b/app/views/home/_logged_in.html.erb
@@ -3,17 +3,21 @@
   <p class="text-base-content/60 mb-8">今日も脳トレをはじめよう</p>
 
   <div class="card bg-base-200 shadow-md w-full max-w-sm mb-8">
-  <div class="card-body items-center text-center">
-    <h2 class="card-title">ベストスコア</h2>
-    <% if @best_score && @best_score > 0 %>
-      <p class="text-4xl font-bold text-primary"><%= @best_score %></p>
-      <p class="text-sm text-base-content/50">問正解</p>
-    <% else %>
-      <p class="text-4xl font-bold text-primary">-</p>
-      <p class="text-sm text-base-content/50">まだプレイ記録がありません</p>
-    <% end %>
+    <div class="card-body">
+      <h2 class="card-title justify-center mb-2">ベストスコア</h2>
+      <% if @best_scores&.any? { |b| b[:score] > 0 } %>
+        <% @best_scores.each do |best_score| %>
+          <div class="flex justify-between items-center py-2 border-b border-base-300 last:border-0">
+            <span class="text-sm text-base-content/60"><%= best_score[:name] %></span>
+            <span class="text-xl font-bold text-primary"><%= best_score[:score] %>問</span>
+          </div>
+        <% end %>
+      <% else %>
+        <p class="text-center text-base-content/50 text-sm">まだプレイ記録がありません</p>
+      <% end %>
+    </div>
   </div>
-</div>
 
-  <%= link_to "プレイする", game_path(@today_game), class: "btn btn-primary btn-lg" %>
+  <%= link_to "ひらがな計算", game_path(@today_game), class: "btn btn-primary btn-lg mb-4" %>
+  <%= link_to "色じゃんけん", game_path(GameType.find_by(name: "color_janken")), class: "btn btn-secondary btn-lg" %>
 </div>

--- a/app/views/home/_logged_out.html.erb
+++ b/app/views/home/_logged_out.html.erb
@@ -110,6 +110,29 @@
       </div>
     <% end %>
 
+    <%# 色じゃんけんカード（仮） %>
+<%= link_to game_path(GameType.find_by(name: "color_janken")), class: "card bg-base-100 shadow-md hover:shadow-lg transition-shadow cursor-pointer group mt-4" do %>
+  <div class="card-body flex-row items-center gap-4">
+    <div class="w-16 h-16 bg-secondary/10 rounded-2xl flex items-center justify-center flex-shrink-0 group-hover:bg-secondary/20 transition-colors">
+      <span class="text-3xl">✊</span>
+    </div>
+    <div class="flex-1 min-w-0">
+      <h3 class="card-title text-lg">色じゃんけん</h3>
+      <p class="text-sm text-base-content/60 mt-1">
+        青い手には勝つ手を、赤い手には負ける手を出そう。<br>
+        30秒で何問解けるか挑戦！
+      </p>
+      <div class="flex gap-2 mt-2">
+        <div class="badge badge-outline badge-sm">初級〜上級</div>
+        <div class="badge badge-outline badge-sm">30秒</div>
+      </div>
+    </div>
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-base-content/30 group-hover:text-secondary transition-colors flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+    </svg>
+  </div>
+<% end %>
+
     <%# Coming soon カード %>
     <div class="card bg-base-100 shadow-sm opacity-50 mt-4">
       <div class="card-body flex-row items-center gap-4">

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Home", type: :request do
   let!(:game_type) { create(:game_type, name: "hiragana_calc") }
+  let!(:color_janken) { create(:game_type, name: "color_janken") }
 
   describe "GET /" do
     it "200を返す" do


### PR DESCRIPTION
ゲームタイプごとのベストスコア表示と色じゃんけんへの導線を追加

## 変更内容
- `BestScoreLoadable`をゲームタイプごとのベストスコア取得に修正
- ホーム画面にゲームタイプごとのベストスコアを表示
- リザルト画面に今プレイしたゲームのベストスコアを表示
- ホーム画面に色じゃんけんへの導線を追加（仮）

closes #76