### PR TITLE
LINEログイン機能を追加（自前OmniAuth Strategy）

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -18,7 +18,58 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     end
   end
 
+  def line
+    auth = request.env["omniauth.auth"]
+
+    if auth.info.email.blank?
+      session["devise.line_data"] = auth.except("extra").to_hash
+      redirect_to line_email_setup_path and return
+    end
+
+    user = User.from_omniauth(auth)
+
+    if user&.persisted?
+      sign_in_and_redirect user, event: :authentication
+      set_flash_message(:notice, :success, kind: "LINE") if is_navigational_format?
+    else
+      session["devise.line_data"] = auth.except("extra").to_hash
+      redirect_to new_user_registration_url,
+                alert: "LINEログインに失敗しました。同じメールアドレスのアカウントが既に登録されている可能性があります。"
+    end
+  end
+
+  def line_email_setup
+    @auth_data = session["devise.line_data"]
+    if @auth_data.blank?
+      redirect_to new_user_session_path,
+                alert: "セッションが無効です。再度LINEログインからお試しください。" and return
+    end
+  end
+
+  def line_complete
+    auth_data = session["devise.line_data"]
+    if auth_data.blank?
+      redirect_to new_user_session_path,
+                alert: "セッションが無効です。再度LINEログインからお試しください。" and return
+    end
+
+    auth = OmniAuth::AuthHash.new(auth_data)
+    email = params.dig(:user, :email).to_s.strip
+
+    user = User.create_from_omniauth_with_email(auth, email)
+
+    if user&.persisted?
+      session.delete("devise.line_data")
+      sign_in_and_redirect user, event: :authentication
+      set_flash_message(:notice, :success, kind: "LINE") if is_navigational_format?
+    else
+      @auth_data = auth_data
+      flash.now[:alert] = "メールアドレスが既に登録されているか、入力内容が無効です。"
+      render :line_email_setup, status: :unprocessable_content
+    end
+  end
+
   def failure
-    redirect_to root_path, alert: "Googleログインに失敗しました。"
+    redirect_to root_path, alert: "認証に失敗しました。もう一度お試しください。"
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
-         :omniauthable, omniauth_providers: [ :google_oauth2 ]
+         :omniauthable, omniauth_providers: [ :google_oauth2, :line ]
 
   has_one :profile, dependent: :destroy
   has_many :scores, dependent: :destroy  # 追加
@@ -12,7 +12,8 @@ class User < ApplicationRecord
   validates :uid, uniqueness: { scope: :provider }, allow_nil: true
 
   def self.from_omniauth(auth)
-    return nil unless auth.info.email_verified
+    return nil if auth.provider == "google_oauth2" && !auth.info.email_verified
+    return nil if auth.info.email.blank?
 
     user = find_by(email: auth.info.email)
     if user
@@ -24,6 +25,18 @@ class User < ApplicationRecord
       u.email = auth.info.email
       u.password = Devise.friendly_token[0, 20]
       u.build_profile(name: auth.info.name)
+    end
+  end
+  def self.create_from_omniauth_with_email(auth, email)
+    return nil if email.blank?
+    return nil if exists?(email: email)
+
+    create do |u|
+      u.provider = auth.provider
+      u.uid = auth.uid
+      u.email = email
+      u.password = Devise.friendly_token[0, 20]
+      u.build_profile(name: auth.info.name.presence || "ユーザー")
     end
   end
 end

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -19,10 +19,13 @@
 <% end %>
 
 <%- if devise_mapping.omniauthable? %>
-  <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= button_to omniauth_authorize_path(resource_name, provider), data: { turbo: false }, class: "btn bg-white text-black border-[#e5e5e5] w-full" do %>
+    <%= button_to omniauth_authorize_path(resource_name, :google_oauth2), data: { turbo: false }, class: "btn bg-white text-black border-[#e5e5e5] w-full" do %>
       <svg aria-label="Google logo" width="16" height="16" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><g><path d="m0 0H512V512H0" fill="#fff"></path><path fill="#34a853" d="M153 292c30 82 118 95 171 60h62v48A192 192 0 0190 341"></path><path fill="#4285f4" d="m386 400a140 175 0 0053-179H260v74h102q-7 37-38 57"></path><path fill="#fbbc02" d="m90 341a208 200 0 010-171l63 49q-12 37 0 73"></path><path fill="#ea4335" d="m153 219c22-69 116-109 179-50l55-54c-78-75-230-72-297 55"></path></g></svg>
       Googleでログイン
     <% end %>
-  <% end %>
+
+    <%= button_to omniauth_authorize_path(resource_name, :line), data: { turbo: false }, class: "btn w-full text-white", style: "background-color: #06C755;" do %>
+      <svg aria-label="Line logo" width="16" height="16" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><g fill-rule="evenodd" stroke-linejoin="round" fill="white"><path fill-rule="nonzero" d="M12.91 6.57c.232 0 .42.19.42.42 0 .23-.188.42-.42.42h-1.17v.75h1.17a.42.42 0 1 1 0 .84h-1.59a.42.42 0 0 1-.418-.42V5.4c0-.23.188-.42.42-.42h1.59a.42.42 0 0 1-.002.84h-1.17v.75h1.17zm-2.57 2.01a.421.421 0 0 1-.757.251l-1.63-2.217V8.58a.42.42 0 0 1-.42.42.42.42 0 0 1-.418-.42V5.4a.418.418 0 0 1 .755-.249L9.5 7.366V5.4c0-.23.188-.42.42-.42.23 0 .42.19.42.42v3.18zm-3.828 0c0 .23-.188.42-.42.42a.42.42 0 0 1-.418-.42V5.4c0-.23.188-.42.42-.42.23 0 .418.19.418.42v3.18zM4.868 9h-1.59c-.23 0-.42-.19-.42-.42V5.4c0-.23.19-.42.42-.42.232 0 .42.19.42.42v2.76h1.17a.42.42 0 1 1 0 .84M16 6.87C16 3.29 12.41.376 8 .376S0 3.29 0 6.87c0 3.208 2.846 5.896 6.69 6.405.26.056.615.172.705.394.08.2.053.518.026.722 0 0-.092.565-.113.685-.035.203-.16.79.693.432.854-.36 4.607-2.714 6.285-4.646C15.445 9.594 16 8.302 16 6.87"></path></g></svg>
+      LINEでログイン
+    <% end %>
 <% end %>

--- a/app/views/users/omniauth_callbacks/line_email_setup.html.erb
+++ b/app/views/users/omniauth_callbacks/line_email_setup.html.erb
@@ -1,0 +1,39 @@
+<div class="flex items-center justify-center py-12 px-4">
+  <div class="max-w-md w-full bg-base-100 rounded-lg shadow-md p-8">
+    <h2 class="text-2xl font-bold text-center mb-2">
+      メールアドレスの登録
+    </h2>
+    <p class="text-sm text-base-content/60 text-center mb-6">
+      LINEからメールアドレスを取得できませんでした。<br>
+      ご利用のメールアドレスを入力してください。
+    </p>
+
+    <% if flash[:alert].present? %>
+      <div class="mb-4 alert alert-error text-sm">
+        <%= flash[:alert] %>
+      </div>
+    <% end %>
+
+    <% line_name = @auth_data&.dig("info", "name") %>
+    <% if line_name.present? %>
+      <p class="text-sm mb-4">
+        LINEアカウント名: <strong><%= line_name %></strong>
+      </p>
+    <% end %>
+
+    <%= form_with url: line_complete_path, method: :post do |f| %>
+      <div class="mb-4">
+        <%= f.label "user[email]", "メールアドレス", class: "block text-sm font-medium mb-1" %>
+        <%= f.email_field "user[email]",
+            autofocus: true,
+            autocomplete: "email",
+            required: true,
+            class: "input input-bordered w-full" %>
+      </div>
+
+      <%= f.submit "メールアドレスを登録してログイン",
+          class: "btn w-full text-white",
+          style: "background-color: #06C755;" %>
+    <% end %>
+  </div>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,5 +24,6 @@ module Myapp
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
     config.i18n.default_locale = :ja
+    Rails.autoloaders.main.ignore(Rails.root.join("lib/omniauth"))
   end
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+
+require Rails.root.join("lib/omniauth/strategies/line")
+
 # Assuming you have not yet modified this file, each configuration option below
 # is set to its default value. Note that some are commented out while others
 # are not: uncommented lines are intended to protect your configuration from
@@ -280,6 +283,9 @@ Devise.setup do |config|
     ENV["GOOGLE_CLIENT_SECRET"],
     callback_url: ENV["GOOGLE_OAUTH_CALLBACK_URL"]
 
+  config.omniauth :line,
+                  ENV["LINE_CHANNEL_ID"],
+                  ENV["LINE_CHANNEL_SECRET"]
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or
   # change the failure app, you can configure them inside the config.warden block.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,15 @@ Rails.application.routes.draw do
     registrations: "users/registrations",
     omniauth_callbacks: "users/omniauth_callbacks"
   }
+
+  devise_scope :user do
+    get  "users/auth/line/email_setup",
+         to: "users/omniauth_callbacks#line_email_setup",
+         as: :line_email_setup
+    post "users/auth/line/complete",
+         to: "users/omniauth_callbacks#line_complete",
+         as: :line_complete
+  end
   root "home#index"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/lib/omniauth/strategies/line.rb
+++ b/lib/omniauth/strategies/line.rb
@@ -1,0 +1,91 @@
+require "omniauth-oauth2"
+require "net/http"
+require "json"
+require "securerandom"
+
+module OmniAuth
+  module Strategies
+    class Line < OmniAuth::Strategies::OAuth2 # Deviseがconfig.omniauth :line と書いたとき、自動的に OmniAuth::Strategies::Line を探しにいく規約があるので、この名前空間が必須
+      option :name, "line"
+      option :scope, "profile openid email"
+
+      option :client_options, {
+        site: "https://api.line.me",
+        authorize_url: "https://access.line.me/oauth2/v2.1/authorize",
+        token_url: "https://api.line.me/oauth2/v2.1/token"
+      }
+
+      uid { raw_info["userId"] }
+
+      info do
+        {
+          name: id_token_info["name"] || raw_info["displayName"],
+          email: id_token_info["email"],
+          image: raw_info["pictureUrl"]
+        }
+      end
+
+      extra do
+        { raw_info: raw_info, id_token_info: id_token_info }
+      end
+
+      def authorize_params
+        super.tap do |params|
+          nonce = SecureRandom.hex(16)
+          session["omniauth.line.nonce"] = nonce
+          params[:nonce] = nonce
+        end
+      end
+
+      def callback_url
+        options[:callback_url].presence ||
+          ENV["LINE_CALLBACK_URL"].presence ||
+          (full_host + script_name + callback_path)
+      end
+
+      def raw_info
+        @raw_info ||= access_token.get("/v2/profile").parsed || {}
+      rescue ::OAuth2::Error, ::Timeout::Error, ::SystemCallError, ::SocketError => e
+        log :error, "raw_info fetch failed: #{e.class}: #{e.message}"
+        {}
+      end
+
+      def id_token_info
+        @id_token_info ||= verify_id_token
+      end
+
+      private
+
+      def verify_id_token
+        id_token = access_token.params["id_token"]
+        return {} if id_token.blank?
+
+        res = Net::HTTP.post_form(
+          URI("https://api.line.me/oauth2/v2.1/verify"),
+          id_token: id_token,
+          client_id: options.client_id
+        )
+        unless res.is_a?(Net::HTTPSuccess)
+          log :error, "verify API non-success status: #{res.code}"
+          return {}
+        end
+
+        payload = JSON.parse(res.body)
+        expected_nonce = session.delete("omniauth.line.nonce")
+        # sessionにnonceが無いケースも含めて拒否(リプレイ攻撃対策)
+        if expected_nonce.blank? || payload["nonce"] != expected_nonce
+          log :error, "nonce verification failed"
+          return {}
+        end
+
+        payload
+      rescue JSON::ParserError => e
+        log :error, "verify API JSON parse error: #{e.message}"
+        {}
+      rescue ::Timeout::Error, ::SystemCallError, ::SocketError => e
+        log :error, "verify API network error: #{e.class}: #{e.message}"
+        {}
+      end
+    end
+  end
+end


### PR DESCRIPTION
自前OmniAuth Strategyを使ってLINEログインを実装。

- lib/omniauth/strategies/line.rb に自前Strategyを作成
- id_tokenの検証はLINEのverify APIに委譲
- nonceによるリプレイ攻撃対策を実装
- LINEからemailが取得できない場合のメアド補完フローを追加
- Render環境でのcallback URL問題をENV変数で対応