### PR TITLE
プロフィール画像のアップロード・削除機能を追加（Active Storage + Cloudinary + libvips）

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -16,6 +16,12 @@ RUN apt-get update -qq \
 && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs yarn vim
 
+# libvipsのインストール
+RUN apt-get update && \
+    apt-get install -y libvips42 libvips-dev && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 # ディレクトリを作成してそれを作業ディレクトリ（Dockerが操作するディレクトリ）に設定
 RUN mkdir /myapp
 WORKDIR /myapp

--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,9 @@ gem "tzinfo-data", platforms: %i[ windows jruby ]
 gem "bootsnap", require: false
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
-# gem "image_processing", "~> 1.2"
+gem "image_processing", "~> 1.2"
+
+gem "cloudinary"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,11 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     cgi (0.5.1)
+    cloudinary (2.4.5)
+      faraday (>= 2.0.1, < 3.0.0)
+      faraday-follow_redirects (~> 0.5)
+      faraday-multipart (~> 1.0, >= 1.0.4)
+      ostruct
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
     crass (1.0.6)
@@ -136,14 +141,29 @@ GEM
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
+    faraday-follow_redirects (0.5.0)
+      faraday (>= 1, < 3)
+    faraday-multipart (1.2.0)
+      multipart-post (~> 2.0)
     faraday-net_http (3.4.2)
       net-http (~> 0.5)
+    ffi (1.17.4-aarch64-linux-gnu)
+    ffi (1.17.4-aarch64-linux-musl)
+    ffi (1.17.4-arm-linux-gnu)
+    ffi (1.17.4-arm-linux-musl)
+    ffi (1.17.4-arm64-darwin)
+    ffi (1.17.4-x86_64-darwin)
+    ffi (1.17.4-x86_64-linux-gnu)
+    ffi (1.17.4-x86_64-linux-musl)
     globalid (1.3.0)
       activesupport (>= 6.1)
     hashie (5.1.0)
       logger
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
+    image_processing (1.14.0)
+      mini_magick (>= 4.9.5, < 6)
+      ruby-vips (>= 2.0.17, < 3)
     io-console (0.8.2)
     irb (1.17.0)
       pp (>= 0.6.0)
@@ -177,11 +197,14 @@ GEM
     matrix (0.4.3)
     mcp (0.8.0)
       json-schema (>= 4.1)
+    mini_magick (5.3.1)
+      logger
     mini_mime (1.1.5)
     minitest (5.27.0)
     msgpack (1.8.0)
     multi_xml (0.9.1)
       bigdecimal (>= 3.1, < 5)
+    multipart-post (2.4.1)
     net-http (0.9.1)
       uri (>= 0.11.1)
     net-imap (0.6.3)
@@ -236,6 +259,7 @@ GEM
       actionpack (>= 4.2)
       omniauth (~> 2.0)
     orm_adapter (0.5.0)
+    ostruct (0.6.3)
     parallel (1.27.0)
     parser (3.3.10.2)
       ast (~> 2.4.1)
@@ -364,6 +388,9 @@ GEM
       rubocop-performance (>= 1.24)
       rubocop-rails (>= 2.30)
     ruby-progressbar (1.13.0)
+    ruby-vips (2.3.0)
+      ffi (~> 1.12)
+      logger
     rubyzip (3.2.2)
     securerandom (0.4.1)
     selenium-webdriver (4.41.0)
@@ -431,6 +458,7 @@ DEPENDENCIES
   bootsnap
   brakeman
   capybara
+  cloudinary
   cssbundling-rails
   debug
   devise
@@ -438,6 +466,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   faker
+  image_processing (~> 1.2)
   jbuilder
   jsbundling-rails
   minitest (< 6)

--- a/app/assets/images/kkrn_icon_user_11.svg
+++ b/app/assets/images/kkrn_icon_user_11.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 800 800" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <g transform="matrix(1,0,0,1,-235,-3091)">
+        <g transform="matrix(2.02015,0,0,2.02017,-51.8034,2534.8)">
+            <rect x="142.327" y="275.741" width="396.011" height="396.011" style="fill:none;"/>
+            <g transform="matrix(0.495014,0,0,0.495007,-1818.69,-130.418)">
+                <circle cx="4361.54" cy="1220.52" r="308.919" style="fill:url(#_Linear1);"/>
+            </g>
+            <g transform="matrix(0.495014,0,0,0.495007,25.6434,-125.031)">
+                <path d="M425.719,1436.12L425.719,1431.17C425.719,1351.48 490.417,1286.78 570.108,1286.78L701.329,1286.78C781.02,1286.78 845.719,1351.48 845.719,1431.17L845.719,1436.12C790.578,1487.27 716.773,1518.55 635.719,1518.55C554.664,1518.55 480.859,1487.27 425.719,1436.12Z" style="fill:white;"/>
+            </g>
+            <g transform="matrix(0.209098,0,0,0.209095,-571.657,182.797)">
+                <circle cx="4361.54" cy="1220.52" r="308.919" style="fill:white;"/>
+            </g>
+        </g>
+    </g>
+    <defs>
+        <linearGradient id="_Linear1" x1="0" y1="0" x2="1" y2="0" gradientUnits="userSpaceOnUse" gradientTransform="matrix(800,-800.011,800.011,800,3961.54,1620.52)"><stop offset="0" style="stop-color:rgb(235,223,204);stop-opacity:1"/><stop offset="1" style="stop-color:rgb(180,167,167);stop-opacity:1"/></linearGradient>
+    </defs>
+</svg>

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Users::RegistrationsController < Devise::RegistrationsController
+  include ImageProcessable
+
   before_action :configure_sign_up_params, only: [ :create ]
   before_action :configure_account_update_params, only: [ :update ]
 
@@ -10,11 +12,6 @@ class Users::RegistrationsController < Devise::RegistrationsController
     resource.build_profile
     respond_with resource
   end
-
-  # POST /resource
-  # def create
-  #   super
-  # end
 
   # GET /resource/edit
   def edit
@@ -26,24 +23,26 @@ class Users::RegistrationsController < Devise::RegistrationsController
     edit_user_registration_path
   end
 
-  # PUT /resource
-  # def update
-  #   super
-  # end
+  def destroy_avatar
+    current_user.profile.avatar.purge
+    redirect_to edit_user_registration_path, notice: "プロフィール画像を削除しました"
+  end
 
-  # DELETE /resource
-  # def destroy
-  #   super
-  # end
-
-  # GET /resource/cancel
-  # Forces the session data which is usually expired after sign
-  # in to be expired now. This is useful if the user wants to
-  # cancel oauth signing in/up in the middle of the process,
-  # removing all OAuth session data.
-  # def cancel
-  #   super
-  # end
+  def update
+    super do |resource|
+      if resource.errors.empty? && params[:user][:profile_attributes][:avatar].present?
+        begin
+          processed = process_and_transform_image(
+            params[:user][:profile_attributes][:avatar], 200
+          )
+          resource.profile.avatar.attach(processed)
+        rescue ImageProcessable::ImageProcessingError => e
+          flash.now[:alert] = e.message
+          render :edit, status: :unprocessable_content and return
+        end
+      end
+    end
+  end
 
   protected
 
@@ -52,26 +51,6 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   def configure_account_update_params
-    devise_parameter_sanitizer.permit(:account_update, keys: [ profile_attributes: [ :name, :id ] ])
+    devise_parameter_sanitizer.permit(:account_update, keys: [ profile_attributes: [ :name, :id, :avatar ] ])
   end
-
-  # If you have extra params to permit, append them to the sanitizer.
-  # def configure_sign_up_params
-  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
-  # end
-
-  # If you have extra params to permit, append them to the sanitizer.
-  # def configure_account_update_params
-  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
-  # end
-
-  # The path used after sign up.
-  # def after_sign_up_path_for(resource)
-  #   super(resource)
-  # end
-
-  # The path used after sign up for inactive accounts.
-  # def after_inactive_sign_up_path_for(resource)
-  #   super(resource)
-  # end
 end

--- a/app/helpers/avatar_helper.rb
+++ b/app/helpers/avatar_helper.rb
@@ -1,0 +1,5 @@
+module AvatarHelper
+  def avatar_url_for(user)
+    user.profile&.avatar&.attached? ? user.profile.avatar : nil
+  end
+end

--- a/app/models/concerns/image_processable.rb
+++ b/app/models/concerns/image_processable.rb
@@ -1,0 +1,30 @@
+module ImageProcessable
+  # エラーの出力を行いたいのでStandardErrorクラスをImageProcessingErrorクラスに継承
+  class ImageProcessingError < StandardError; end
+
+  # 画像処理メソッド。image_ioにはparams[:post][:image]の中の一時ファイルを渡す
+  # widthには横幅の最大値を渡す
+  def process_and_transform_image(image_io, width)
+    return unless image_io.present?
+
+    begin
+      # 画像処理の部分。横幅に合うようにアスペクト比を維持してリサイズ、その後webpに変換する
+      processed_image = ImageProcessing::Vips
+        .source(image_io)
+        .resize_to_fit(width, nil)
+        .convert("webp")
+        .saver(strip: true, quality: 85)
+        .call
+
+      # ActionDispatch::Http::UploadedFileを返す
+      ActionDispatch::Http::UploadedFile.new(
+        tempfile: processed_image,
+        filename: "#{File.basename(image_io.original_filename, '.*')}.webp",
+        type: "image/webp"
+      )
+    rescue => e
+      Rails.logger.error "Image processing error: #{e.message}"
+      raise ImageProcessingError, "画像の処理中にエラーが発生しました: #{e.message}"
+    end
+  end
+end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,4 +1,5 @@
 class Profile < ApplicationRecord
   belongs_to :user
   validates :name, presence: true
+  has_one_attached :avatar
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -12,8 +12,20 @@
       <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
         <%= render "devise/shared/error_messages", resource: resource %>
 
-        <%# 名前 %>
         <%= f.fields_for :profile do |profile_form| %>
+          <%# プロフィール画像 %>
+          <div class="form-control gap-1 mb-4">
+            <%= profile_form.label :avatar, "プロフィール画像", class: "label-text font-medium" %>
+            <% if resource.profile&.avatar&.attached? && resource.profile.avatar.persisted?  %>
+              <div class="mb-2 flex items-center gap-2">
+                <%= image_tag resource.profile.avatar, class: "w-16 h-16 rounded-full object-cover" %>
+              </div>
+            <% end %>
+            <%= profile_form.file_field :avatar, class: "file-input file-input-bordered w-full",
+                accept: "image/jpeg,image/png,image/gif,image/webp" %>
+          </div>
+
+          <%# 名前 %>
           <div class="form-control gap-1 mb-4">
             <%= profile_form.label :name, class: "label-text font-medium" %>
             <%= profile_form.text_field :name, class: "input input-bordered w-full" %>
@@ -60,6 +72,16 @@
         <%# 更新ボタン %>
         <%= f.submit t("helpers.submit.update"), class: "btn btn-primary w-full" %>
 
+      <% end %>
+
+      <%# 画像削除ボタン %>
+      <% if resource.profile&.avatar&.attached? && resource.profile.avatar.persisted? %>
+        <div class="mb-4">
+          <%= button_to "画像を削除", destroy_user_avatar_path,
+              data: { turbo_confirm: "プロフィール画像を削除しますか？" },
+              method: :delete,
+              class: "btn btn-error btn-sm btn-outline w-full" %>
+        </div>
       <% end %>
 
       <%# アカウント削除 %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -16,10 +16,12 @@
   <div class="navbar-end">
     <% if user_signed_in? %>
       <div class="dropdown dropdown-end">
-        <div tabindex="0" role="button" class="btn btn-ghost btn-circle">
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-          </svg>
+        <div tabindex="0" role="button" class="btn btn-ghost btn-circle avatar">
+          <% if avatar_url_for(current_user) %>
+            <%= image_tag avatar_url_for(current_user), class: "w-10 h-10 rounded-full object-cover" %>
+          <% else %>
+            <%= image_tag "kkrn_icon_user_11.svg", class: "w-10 h-10 rounded-full" %>
+          <% end %>
         </div>
         <ul tabindex="0" class="menu menu-sm dropdown-content bg-base-100 rounded-box z-[1] mt-3 w-52 p-2 shadow">
           <li><%= link_to "設定", edit_user_registration_path %></li>

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,5 +25,6 @@ module Myapp
     # config.eager_load_paths << Rails.root.join("extras")
     config.i18n.default_locale = :ja
     Rails.autoloaders.main.ignore(Rails.root.join("lib/omniauth"))
+    config.active_storage.variant_processor = :vips
   end
 end

--- a/config/cloudinary.yml
+++ b/config/cloudinary.yml
@@ -1,0 +1,11 @@
+development:
+  cloud_name: <%= ENV["CLOUDINARY_CLOUD_NAME"] %>
+  api_key: <%= ENV["CLOUDINARY_API_KEY"] %>
+  api_secret: <%= ENV["CLOUDINARY_API_SECRET"] %>
+  secure: true
+
+production:
+  cloud_name: <%= ENV["CLOUDINARY_CLOUD_NAME"] %>
+  api_key: <%= ENV["CLOUDINARY_API_KEY"] %>
+  api_secret: <%= ENV["CLOUDINARY_API_SECRET"] %>
+  secure: true

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -32,7 +32,7 @@ Rails.application.configure do
   end
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  config.active_storage.service = :cloudinary
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -37,7 +37,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  config.active_storage.service = :cloudinary
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,9 @@ Rails.application.routes.draw do
     post "users/auth/line/complete",
          to: "users/omniauth_callbacks#line_complete",
          as: :line_complete
+    delete "users/avatar",
+       to: "users/registrations#destroy_avatar",
+       as: :destroy_user_avatar
   end
   root "home#index"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -6,6 +6,9 @@ local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
 
+cloudinary:
+  service: Cloudinary
+
 # Use bin/rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 # amazon:
 #   service: S3

--- a/db/migrate/20260524154758_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20260524154758_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,57 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [ primary_key_type, foreign_key_type ]
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,37 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_16_125815) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_24_154758) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "game_types", force: :cascade do |t|
     t.string "name", null: false
@@ -57,6 +85,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_16_125815) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "profiles", "users"
   add_foreign_key "scores", "game_types"
   add_foreign_key "scores", "users"


### PR DESCRIPTION
Active Storage + Cloudinary + libvipsを使ってプロフィール画像のアップロード・削除機能を実装。

- Cloudinaryをストレージとして設定
- libvipsでアップロード前に200×200にリサイズしてwebpに変換
- 設定画面で画像のアップロード・削除が可能
- ヘッダーにアバター画像を表示（未設定時はデフォルトアイコン）
- ImageProcessableモジュールで画像処理ロジックを共通化

close #87