### PR TITLE
ログイン後トップページにスコア推移グラフを追加

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -4,5 +4,20 @@ class HomeController < ApplicationController
 
   def index
     @today_game = GameType.find_by(name: "hiragana_calc")
+
+    if user_signed_in?
+      @chart_data = GameType.all.each_with_object({}) do |gt, hash|
+        scores = current_user.scores
+                            .where(game_type: gt)
+                            .order(played_on: :asc)
+                            .last(10)
+        hash[gt.display_name] = {
+          labels: scores.map { |s| s.played_on.strftime("%-m/%-d") },
+          datasets: [ {
+            data: scores.map(&:score)
+          } ]
+        }
+      end
+    end
   end
 end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -18,3 +18,7 @@ application.register("hiragana-calc", HiraganaCalcController)
 
 import ColorGridController from "./color_grid_controller"
 application.register("color-grid", ColorGridController)
+
+import ScoreChartController from "./score_chart_controller"
+application.register("score-chart", ScoreChartController)
+

--- a/app/javascript/controllers/score_chart_controller.js
+++ b/app/javascript/controllers/score_chart_controller.js
@@ -1,0 +1,64 @@
+import { Controller } from "@hotwired/stimulus"
+import { Chart, LineController, LineElement, PointElement, LinearScale, CategoryScale, Filler, Tooltip } from "chart.js"
+
+Chart.register(LineController, LineElement, PointElement, LinearScale, CategoryScale, Filler, Tooltip)
+
+export default class extends Controller {
+  static targets = ["canvas", "legendText"]
+  static values  = { chartJson: Object }
+
+  connect() {
+    const firstGame = Object.keys(this.chartJsonValue)[0]
+    this._buildChart(firstGame)
+    if (this.hasLegendTextTarget) {
+      this.legendTextTarget.textContent = `${firstGame}スコア推移`
+    }
+  }
+
+  disconnect() {
+    this.chart?.destroy()
+  }
+
+  switchTab(e) {
+    const game = e.currentTarget.dataset.game
+
+    this.element.querySelectorAll("[data-game]").forEach(btn => {
+      btn.classList.toggle("btn-primary", btn.dataset.game === game)
+      btn.classList.toggle("btn-ghost", btn.dataset.game !== game)
+    })
+
+    const d = this.chartJsonValue[game]
+    this.chart.data.labels = d.labels
+    this.chart.data.datasets[0].data = d.datasets[0].data
+    this.chart.update()
+
+    if (this.hasLegendTextTarget) {
+      this.legendTextTarget.textContent = `${game}スコア推移`
+    }
+  }
+
+  _buildChart(game) {
+    const d = this.chartJsonValue[game]
+    this.chart = new Chart(this.canvasTarget, {
+      type: "line",
+      data: {
+        labels: d.labels,
+        datasets: [{
+          data: d.datasets[0].data,
+          borderColor: "#059669",
+          backgroundColor: "rgba(5,150,105,0.15)",
+          borderWidth: 2,
+          pointRadius: 4,
+          tension: 0.35,
+          fill: true
+        }]
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: { legend: { display: false } },
+        scales: { y: { beginAtZero: true } }
+      }
+    })
+  }
+}

--- a/app/views/home/_logged_in.html.erb
+++ b/app/views/home/_logged_in.html.erb
@@ -18,6 +18,35 @@
     </div>
   </div>
 
+  <%# グラフ %>
+  <div class="card bg-base-200 shadow-md w-full max-w-sm mb-8"
+      data-controller="score-chart"
+      data-score-chart-chart-json-value="<%= @chart_data.to_json %>">
+    <div class="card-body">
+      <h2 class="card-title justify-center mb-2">スコア推移</h2>
+
+      <%# タブ %>
+      <div class="flex gap-2 mb-4">
+        <% @chart_data.keys.each_with_index do |name, i| %>
+          <button data-action="click->score-chart#switchTab"
+                  data-game="<%= name %>"
+                  class="btn btn-sm <%= i == 0 ? 'btn-primary' : 'btn-ghost' %>">
+            <%= name %>
+          </button>
+        <% end %>
+      </div>
+
+      <%# グラフ %>
+      <div style="height: 200px;">
+        <canvas data-score-chart-target="canvas"></canvas>
+      </div>
+
+      <%# 凡例 %>
+      <p class="text-sm text-center mt-2 text-base-content/60"
+        data-score-chart-target="legendText"></p>
+    </div>
+  </div>
+
   <%= link_to "ひらがな計算", game_path(@today_game), class: "btn btn-primary btn-lg mb-4" %>
   <%= link_to "色じゃんけん", game_path(GameType.find_by(name: "color_janken")), class: "btn btn-secondary btn-lg" %>
 </div>

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@hotwired/stimulus": "^3.2.2",
     "@hotwired/turbo-rails": "^8.0.23",
     "@tailwindcss/cli": "^4.2.1",
+    "chart.js": "^4.5.1",
     "daisyui": "^5.5.19",
     "tailwindcss": "^4.2.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -206,6 +206,11 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@kurkle/color@^0.3.0":
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/@kurkle/color/-/color-0.3.4.tgz#4d4ff677e1609214fc71c580125ddddd86abcabf"
+  integrity sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==
+
 "@napi-rs/wasm-runtime@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz#c3705ab549d176b8dc5172723d6156c3dc426af2"
@@ -426,6 +431,13 @@
   integrity sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==
   dependencies:
     tslib "^2.4.0"
+
+chart.js@^4.5.1:
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-4.5.1.tgz#19dd1a9a386a3f6397691672231cb5fc9c052c35"
+  integrity sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==
+  dependencies:
+    "@kurkle/color" "^0.3.0"
 
 daisyui@^5.5.19:
   version "5.5.19"


### PR DESCRIPTION
概要
ログイン後のトップページにスコア推移グラフを追加しました。
変更内容

Chart.js + 自前Stimulusコントローラでスコア推移グラフを実装
ゲームタイプごとにタブ切替でグラフを表示
未ログインユーザーはグラフを表示しない（user_signed_in?で条件分岐）

技術的な判断

@stimulus-components/chartjsではなくChart.jsを直接使用（タブ切替の柔軟性のため）
disconnect()でChart.jsインスタンスを破棄してメモリリークを防止

Closes #88