### PR TITLE
不正解音・赤フラッシュを3ゲーム共通化

### DIFF
--- a/app/javascript/controllers/color_grid_controller.js
+++ b/app/javascript/controllers/color_grid_controller.js
@@ -14,7 +14,6 @@ export default class extends Controller {
   connect() {
     this.isProcessing  = false// 処理中フラグをfalseで初期化
     this.correctStreak = 0// 連続正解数を0で初期化
-    this.audioCtx      = null// 音声をまだ使わないのでnullで初期化
     this.renderGrids()// グリッドを描画するメソッドを呼ぶ
   }
 
@@ -56,7 +55,6 @@ export default class extends Controller {
 
    selectCell(event) {
     if (this.isProcessing) return
-    this.initAudio()
 
     const cell     = event.currentTarget
     const index    = parseInt(cell.dataset.index)
@@ -74,7 +72,6 @@ export default class extends Controller {
     const isCorrectDir = this.sampleValue.includes(index) === newValue
     if (!isCorrectDir) {
       this.dispatch("error", { bubbles: true })
-      this.playErrorSound()  // ← 音をエラー時に鳴らす記述
       return
     }
 
@@ -132,18 +129,4 @@ export default class extends Controller {
     this.isProcessing = true
   }
 
-  initAudio() {
-    if (!this.audioCtx) {
-      this.audioCtx = new AudioContext()
-    }
-  }
-
-  playErrorSound() {
-    const osc = this.audioCtx.createOscillator()
-    osc.type = "square"
-    osc.frequency.value = 220
-    osc.connect(this.audioCtx.destination)
-    osc.start()
-    osc.stop(this.audioCtx.currentTime + 0.15)
-  }
 }

--- a/app/javascript/controllers/game_controller.js
+++ b/app/javascript/controllers/game_controller.js
@@ -48,6 +48,8 @@ export default class extends Controller {
         bubbles: true,
         cancelable: false
       })
+    } else {
+      this.gameError()
     }
   }
   finish() {
@@ -61,6 +63,17 @@ export default class extends Controller {
 
   gameError(event) {
     this.flashBanner()
+    this.playErrorSound()
+  }
+
+  playErrorSound() {
+    const ctx = new AudioContext()
+    const osc = ctx.createOscillator()
+    osc.type = "square"
+    osc.frequency.value = 220
+    osc.connect(ctx.destination)
+    osc.start()
+    osc.stop(ctx.currentTime + 0.15)
   }
 
   flashBanner() {

--- a/app/views/games/play.html.erb
+++ b/app/views/games/play.html.erb
@@ -4,6 +4,11 @@
      data-controller="game"
      data-game-answer-value="<%= @question[:answer] %>">
 
+  <%# 上部エラーバナー %>
+  <div data-game-target="errorBanner"
+       class="fixed top-0 left-0 w-full h-2 opacity-0 bg-error transition-opacity duration-300">
+  </div>
+
   <%# スコアとタイマー %>
   <div class="flex justify-between items-center py-4">
     <div class="badge badge-primary badge-lg gap-1">

--- a/app/views/home/_logged_in.html.erb
+++ b/app/views/home/_logged_in.html.erb
@@ -48,5 +48,6 @@
   </div>
 
   <%= link_to "ひらがな計算", game_path(@today_game), class: "btn btn-primary btn-lg mb-4" %>
-  <%= link_to "色じゃんけん", game_path(GameType.find_by(name: "color_janken")), class: "btn btn-secondary btn-lg" %>
+  <%= link_to "色じゃんけん", game_path(GameType.find_by(name: "color_janken")), class: "btn btn-secondary btn-lg mb-4" %>
+  <%= link_to "色マス記憶", game_path(GameType.find_by(name: "color_grid")), class: "btn btn-accent btn-lg" %>
 </div>

--- a/app/views/home/_logged_out.html.erb
+++ b/app/views/home/_logged_out.html.erb
@@ -133,6 +133,28 @@
   </div>
 <% end %>
 
+<%= link_to game_path(GameType.find_by(name: "color_grid")), class: "card bg-base-100 shadow-md hover:shadow-lg transition-shadow cursor-pointer group mt-4" do %>
+  <div class="card-body flex-row items-center gap-4">
+    <div class="w-16 h-16 bg-accent/10 rounded-2xl flex items-center justify-center flex-shrink-0 group-hover:bg-accent/20 transition-colors">
+      <span class="text-3xl">🟩</span>
+    </div>
+    <div class="flex-1 min-w-0">
+      <h3 class="card-title text-lg">色マス記憶</h3>
+      <p class="text-sm text-base-content/60 mt-1">
+        見本と同じマス配置を再現しよう。<br>
+        30秒で何問解けるか挑戦！
+      </p>
+      <div class="flex gap-2 mt-2">
+        <div class="badge badge-outline badge-sm">初級〜上級</div>
+        <div class="badge badge-outline badge-sm">30秒</div>
+      </div>
+    </div>
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-base-content/30 group-hover:text-accent transition-colors flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+    </svg>
+  </div>
+<% end %>
+
     <%# Coming soon カード %>
     <div class="card bg-base-100 shadow-sm opacity-50 mt-4">
       <div class="card-body flex-row items-center gap-4">

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe "Home", type: :request do
   let!(:game_type) { create(:game_type, name: "hiragana_calc") }
   let!(:color_janken) { create(:game_type, name: "color_janken") }
+  let!(:color_grid) { create(:game_type, name: "color_grid") }
 
   describe "GET /" do
     it "200を返す" do


### PR DESCRIPTION
## 概要
不正解音・赤フラッシュを3ゲーム共通化

## 実装内容
- game_controller.jsにplayErrorSound・flashBannerを追加
- selectAnswer()に不正解時のgameError()呼び出しを追加
- play.html.erbにerrorBannerを追加
- color_grid_controller.jsからplayErrorSound・initAudioを削除
- ホーム画面に色マス記憶のリンクを追加

 Closes #82