### PR TITLE
fix: スマホでグリッドの枠線が二重に表示される問題を修正

### DIFF
--- a/app/javascript/controllers/color_grid_controller.js
+++ b/app/javascript/controllers/color_grid_controller.js
@@ -27,10 +27,8 @@ export default class extends Controller {
     grid.innerHTML = ""
     for (let i = 0; i < this.GRID_SIZE; i++) {
       const cell = document.createElement("div")
-      cell.classList.add("w-12", "h-12", "border", "border-base-content/30")
-      if (this.sampleValue.includes(i)) {
-        cell.classList.add("bg-warning")
-      }
+      cell.classList.add("w-12", "h-12")
+      cell.classList.add(this.sampleValue.includes(i) ? "bg-warning" : "bg-base-100")
       grid.appendChild(cell)
     }
   }
@@ -43,12 +41,10 @@ export default class extends Controller {
       cell.dataset.index  = i
       cell.dataset.action = "click->color-grid#selectCell"
       cell.classList.add(
-        "w-12", "h-12", "border", "border-base-content/30",
+        "w-12", "h-12",
         "cursor-pointer", "transition-colors", "duration-150"
       )
-      if (this.answerValue.includes(i)) {
-        cell.classList.add("bg-primary")
-      }
+      cell.classList.add(this.answerValue.includes(i) ? "bg-primary" : "bg-base-100")
       grid.appendChild(cell)
     }
   }
@@ -62,6 +58,7 @@ export default class extends Controller {
     const newValue = !isOn
 
     cell.classList.toggle("bg-primary", newValue)
+    cell.classList.toggle("bg-base-100", !newValue)
 
     if (newValue) {
       this.answerValue = [...this.answerValue, index]

--- a/app/views/games/color_grid.html.erb
+++ b/app/views/games/color_grid.html.erb
@@ -24,14 +24,14 @@
     <div>
       <p class="text-center mb-2">見本</p>
       <div data-color-grid-target="sampleGrid"
-           class="grid grid-cols-4 border border-base-content/30">
+             class="grid grid-cols-4 gap-px bg-base-content/30 border border-base-content/30">
       </div>
     </div>
     <%# 回答グリッド %>
     <div>
       <p class="text-center mb-2">回答</p>
       <div data-color-grid-target="answerGrid"
-           class="grid grid-cols-4 border border-base-content/30">
+             class="grid grid-cols-4 gap-px bg-base-content/30 border border-base-content/30">
       </div>
     </div>
   </div>


### PR DESCRIPTION
## 概要
色マス記憶ゲームのグリッドが、iPhone(スマホ)で表示したときに
枠線が二重にずれて表示される問題を修正しました。

## 原因
各セルが4辺すべてに1pxのborderを持っており、隣接セル同士のborderが
重なって1本に見える状態だった。
スマホでは画面幅をセル数で割った際に端数が生じ、サブピクセルの丸めに
よって重なっていたborderが分離し、二重線として表示されていた。

## 対応
borderを重ねない設計に変更。
- グリッドコンテナに `gap-px` と背景色(`bg-base-content/30`)を設定し、
  セル間の1pxの隙間から透ける背景色を罫線として表示する方式に変更
- 各セルからborderクラスを削除し、全セルに不透明な背景色を必ず付与
  (`bg-base-100` / `bg-warning` / `bg-primary` を排他的に切り替え)
