### PR TITLE
fix: セルの固定幅をやめて画面幅に追従するレスポンシブな実装に修正

### DIFF
--- a/app/javascript/controllers/color_grid_controller.js
+++ b/app/javascript/controllers/color_grid_controller.js
@@ -27,7 +27,7 @@ export default class extends Controller {
     grid.innerHTML = ""
     for (let i = 0; i < this.GRID_SIZE; i++) {
       const cell = document.createElement("div")
-      cell.classList.add("w-12", "h-12")
+      cell.classList.add("aspect-square")
       cell.classList.add(this.sampleValue.includes(i) ? "bg-warning" : "bg-base-100")
       grid.appendChild(cell)
     }
@@ -41,7 +41,7 @@ export default class extends Controller {
       cell.dataset.index  = i
       cell.dataset.action = "click->color-grid#selectCell"
       cell.classList.add(
-        "w-12", "h-12",
+        "aspect-square",
         "cursor-pointer", "transition-colors", "duration-150"
       )
       cell.classList.add(this.answerValue.includes(i) ? "bg-primary" : "bg-base-100")

--- a/app/views/games/color_grid.html.erb
+++ b/app/views/games/color_grid.html.erb
@@ -21,14 +21,14 @@
   <%# 2グリッド並列 %>
   <div class="flex gap-8 justify-center">
     <%# 見本グリッド %>
-    <div>
+    <div class="w-full max-w-[12rem]">
       <p class="text-center mb-2">見本</p>
       <div data-color-grid-target="sampleGrid"
              class="grid grid-cols-4 gap-px bg-base-content/30 border border-base-content/30">
       </div>
     </div>
     <%# 回答グリッド %>
-    <div>
+    <div class="w-full max-w-[12rem]">
       <p class="text-center mb-2">回答</p>
       <div data-color-grid-target="answerGrid"
              class="grid grid-cols-4 gap-px bg-base-content/30 border border-base-content/30">


### PR DESCRIPTION
## 概要
色マス記憶ゲームのグリッドがスマホの画面幅に収まらず、
セルがはみ出して縦の罫線が隠れたり、回答グリッドが画面右に
見切れたりする問題を修正しました。

## 原因
セルのサイズが w-12 h-12(48px固定)だったため、スマホの画面幅では
2つのグリッド(約197px×2+余白)が収まらず、縮んだグリッド列から
セルがはみ出していた。

「枠線が二重に表示される問題」も、
根本原因はこのはみ出しによるborderの重なりだった。
前回はborderを重ねない設計(gap方式)への変更で症状を解消し、
本PRで根本原因である固定幅を解消する。

## 対応
- セルの `w-12 h-12` を `aspect-square` に変更し、
  サイズを列幅に追従させつつ正方形を維持するレスポンシブな実装に変更
- グリッドのラッパーに `w-full max-w-[12rem]` を追加し、
  スマホでは画面幅に応じて縮小、PCでは従来とほぼ同じ最大192pxで表示