### PR TITLE
feat: 使い方セクションの整備とナビゲーションのリンク導線追加

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.23.0)
       msgpack (~> 1.2)
-    brakeman (8.0.4)
+    brakeman (8.0.5)
       racc
     builder (3.3.0)
     capybara (3.40.0)

--- a/app/views/games/_color_grid_description.html.erb
+++ b/app/views/games/_color_grid_description.html.erb
@@ -1,8 +1,35 @@
-<div class="card bg-base-100 shadow-xl mb-8">
-  <div class="card-body">
-    <h1 class="card-title text-3xl font-bold justify-center mb-4">色マス記憶</h1>
-    <p class="text-center text-base-content/70">
-      見本と同じマス配置を再現しよう
-    </p>
+<div class="text-center mb-10">
+  <div class="w-20 h-20 bg-primary/10 rounded-3xl flex items-center justify-center mx-auto mb-6">
+    <span class="text-5xl">🟨</span>
+  </div>
+  <h1 class="text-4xl font-extrabold text-base-content mb-2">
+    <%= @game_type.display_name %>
+  </h1>
+  <p class="text-base-content/60 text-sm">
+    <%= @game_type.description %>
+  </p>
+</div>
+
+<div class="grid grid-cols-3 gap-4 mb-10">
+  <div class="card bg-base-100 shadow-sm">
+    <div class="card-body items-center text-center p-4 gap-2">
+      <span class="text-2xl">👀</span>
+      <p class="text-xs font-semibold text-base-content">見本を見る</p>
+      <p class="text-xs text-base-content/50">マスの位置を確認</p>
+    </div>
+  </div>
+  <div class="card bg-base-100 shadow-sm">
+    <div class="card-body items-center text-center p-4 gap-2">
+      <span class="text-2xl">👆</span>
+      <p class="text-xs font-semibold text-base-content">同じ位置をタップ</p>
+      <p class="text-xs text-base-content/50">回答マスで再現</p>
+    </div>
+  </div>
+  <div class="card bg-base-100 shadow-sm">
+    <div class="card-body items-center text-center p-4 gap-2">
+      <span class="text-2xl">⏱️</span>
+      <p class="text-xs font-semibold text-base-content">30秒で挑戦</p>
+      <p class="text-xs text-base-content/50">何問解けるか</p>
+    </div>
   </div>
 </div>

--- a/app/views/home/_logged_out.html.erb
+++ b/app/views/home/_logged_out.html.erb
@@ -37,45 +37,53 @@
   </div>
 </section>
 
-<%# ===== 特徴セクション ===== %>
-<section class="py-16 px-4 bg-base-100">
+<%# ===== 使い方セクション ===== %>
+<section id="how-to" class="py-16 px-4 bg-base-100 scroll-mt-20">
   <div class="max-w-4xl mx-auto">
+    <div class="badge badge-primary badge-outline mb-3 mx-auto block w-fit">使い方</div>
     <h2 class="text-2xl sm:text-3xl font-bold text-center text-base-content mb-2">
-      脳のスキトレの特徴
+      かんたん3ステップ
     </h2>
-    <p class="text-center text-base-content/50 mb-10 text-sm">続けやすい仕組みで、毎日の習慣に</p>
+    <p class="text-center text-base-content/50 mb-10 text-sm">登録なしでもすぐ遊べます</p>
 
     <div class="grid grid-cols-1 sm:grid-cols-3 gap-6">
       <div class="card bg-base-200 shadow-sm hover:shadow-md transition-shadow">
         <div class="card-body items-center text-center gap-3">
+          <div class="badge badge-primary badge-lg">1</div>
+          <div class="text-4xl">👀</div>
+          <h3 class="card-title text-base">ゲームを選ぶ</h3>
+          <p class="text-sm text-base-content/60">
+            3種類の脳トレから、好きなものを選んでスタート。
+          </p>
+        </div>
+      </div>
+
+      <div class="card bg-base-200 shadow-sm hover:shadow-md transition-shadow">
+        <div class="card-body items-center text-center gap-3">
+          <div class="badge badge-primary badge-lg">2</div>
           <div class="text-4xl">⏱️</div>
-          <h3 class="card-title text-base">30秒で完結</h3>
+          <h3 class="card-title text-base">30秒チャレンジ</h3>
           <p class="text-sm text-base-content/60">
-            忙しい朝でも大丈夫。たった30秒のゲームで脳をウォームアップできます。
+            制限時間内に、できるだけ多く正解しよう。
           </p>
         </div>
       </div>
 
       <div class="card bg-base-200 shadow-sm hover:shadow-md transition-shadow">
         <div class="card-body items-center text-center gap-3">
+          <div class="badge badge-primary badge-lg">3</div>
           <div class="text-4xl">📈</div>
-          <h3 class="card-title text-base">スコアを記録</h3>
+          <h3 class="card-title text-base">成長をふりかえる</h3>
           <p class="text-sm text-base-content/60">
-            プレイするたびにスコアが記録され、成長グラフで上達を実感できます。
-          </p>
-        </div>
-      </div>
-
-      <div class="card bg-base-200 shadow-sm hover:shadow-md transition-shadow">
-        <div class="card-body items-center text-center gap-3">
-          <div class="text-4xl">🧩</div>
-          <h3 class="card-title text-base">複数のゲーム</h3>
-          <p class="text-sm text-base-content/60">
-            ひらがな計算など、脳の異なる部位を刺激するゲームを順次追加予定。
+            スコアをグラフで記録。過去の自分を超えよう。
           </p>
         </div>
       </div>
     </div>
+
+    <p class="text-center text-xs text-base-content/40 mt-8">
+      ※スコアの記録とグラフ表示には無料の会員登録が必要です
+    </p>
   </div>
 </section>
 

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -7,9 +7,12 @@
 
   <div class="navbar-center hidden lg:flex">
     <ul class="menu menu-horizontal px-1">
-      <li><%= link_to "脳トレを選ぶ", "#" %></li>
-      <li><%= link_to "スコア履歴", "#" %></li>
-      <li><%= link_to "使い方", "#" %></li>
+      <% if user_signed_in? %>
+        <li><%= link_to "脳トレを選ぶ", root_path %></li>
+      <% else %>
+        <li><%= link_to "脳トレを選ぶ", "#{root_path}#games" %></li>
+        <li><%= link_to "使い方", "#{root_path}#how-to" %></li>
+      <% end %>
     </ul>
   </div>
 


### PR DESCRIPTION
## 概要
ログアウト時のトップページに「使い方」セクション（かんたん3ステップ）を追加し、
ナビゲーションの各リンクを実際のスクロール先・ページに接続しました。

## 変更内容
### 使い方セクションの追加
- ログアウト時トップ（_logged_out）の特徴セクションを、
  番号付きの「かんたん3ステップ」形式に変更
  （①ゲームを選ぶ ②30秒チャレンジ ③成長をふりかえる）
- アンカーリンク用に `id="how-to"` を付与

### ナビゲーションのリンク整備
- これまで `#`（リンク先なし）だった各メニューを実際の導線に接続
- ログイン状態に応じて表示を出し分け、リンク切れを防止
  - ログイン後: 「脳トレを選ぶ」（ダッシュボードへ）
  - ログイン前: 「脳トレを選ぶ」（ゲーム紹介セクション #games へ）、
    「使い方」（#how-to へ）
- 行き先のない「スコア履歴」リンクを削除
  （ログイン後はトップがスコアダッシュボードを兼ねるため）
Closes #94