### PR TITLE
N+1問題を解消: チャートデータ生成でスコアを一括取得・bullet導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,7 @@ end
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
+  gem "bullet"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,9 @@ GEM
     brakeman (8.0.5)
       racc
     builder (3.3.0)
+    bullet (8.1.3)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     capybara (3.40.0)
       addressable
       matrix
@@ -426,6 +429,7 @@ GEM
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
+    uniform_notifier (1.18.0)
     uri (1.1.1)
     useragent (0.16.11)
     version_gem (1.1.9)
@@ -459,6 +463,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   brakeman
+  bullet
   capybara
   cloudinary
   cssbundling-rails

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -6,16 +6,16 @@ class HomeController < ApplicationController
     @today_game = GameType.find_by(name: "hiragana_calc")
 
     if user_signed_in?
+      # 全スコアを1回だけ取得（ループの外）
+      all_scores = current_user.scores.order(played_on: :asc).to_a
+
       @chart_data = GameType.all.each_with_object({}) do |gt, hash|
-        scores = current_user.scores
-                            .where(game_type: gt)
-                            .order(played_on: :asc)
-                            .last(10)
+        # DBに行かず、取得済みのall_scoresから選ぶだけ
+        scores = all_scores.select { |s| s.game_type_id == gt.id }.last(10)
+
         hash[gt.display_name] = {
           labels: scores.map { |s| s.played_on.strftime("%-m/%-d") },
-          datasets: [ {
-            data: scores.map(&:score)
-          } ]
+          datasets: [ { data: scores.map(&:score) } ]
         }
       end
     end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,15 @@
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
+  config.after_initialize do
+    Bullet.enable        = true
+    Bullet.alert         = true
+    Bullet.bullet_logger = true
+    Bullet.console       = true
+    Bullet.rails_logger  = true
+    Bullet.add_footer    = true
+  end
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded any time


### PR DESCRIPTION
## 概要
ホーム画面のスコア推移グラフ生成部分で発生していたN+1問題を解消する。

## 背景
コードレビューで、`@chart_data` 作成時にゲームごとに都度スコアをDBから取得しており、N+1が発生している点を指摘された。

## 変更内容
- スコアをループ内で都度取得（`current_user.scores.where(game_type: gt)`）していた処理を、ループ外で一括取得（`current_user.scores.order(...).to_a`）し、メモリ上で `select` して振り分ける形に修正する
- N+1検出のため bullet gem を導入する
