### PR TITLE
プロフィール画像にファイルサイズ上限（2MB）のバリデーションを追加

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -29,12 +29,19 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   def update
+    avatar = params.dig(:user, :profile_attributes, :avatar)
+
+    if avatar.present? && !image_size_valid?(avatar)
+      self.resource = current_user
+      resource.profile || resource.build_profile
+      flash.now[:alert] = "画像サイズは2MB以下にしてください"
+      return render :edit, status: :unprocessable_content
+    end
+
     super do |resource|
-      if resource.errors.empty? && params[:user][:profile_attributes][:avatar].present?
+      if resource.errors.empty? && avatar.present?
         begin
-          processed = process_and_transform_image(
-            params[:user][:profile_attributes][:avatar], 200
-          )
+          processed = process_and_transform_image(avatar, 200)
           resource.profile.avatar.attach(processed)
         rescue ImageProcessable::ImageProcessingError => e
           flash.now[:alert] = e.message

--- a/app/models/concerns/image_processable.rb
+++ b/app/models/concerns/image_processable.rb
@@ -2,6 +2,12 @@ module ImageProcessable
   # エラーの出力を行いたいのでStandardErrorクラスをImageProcessingErrorクラスに継承
   class ImageProcessingError < StandardError; end
 
+  MAX_IMAGE_SIZE = 2.megabytes
+
+  def image_size_valid?(image_io)
+    image_io.size <= MAX_IMAGE_SIZE
+  end
+
   # 画像処理メソッド。image_ioにはparams[:post][:image]の中の一時ファイルを渡す
   # widthには横幅の最大値を渡す
   def process_and_transform_image(image_io, width)


### PR DESCRIPTION
## 概要
プロフィール画像のアップロードに、ファイルサイズの上限（2MB）バリデーションを追加する。

## 背景
コードレビューで、画像処理がリクエスト内で同期的に行われており、大きな画像がアップロードされると処理が重くなる懸念を指摘された。まずアップロード前にサイズをチェックする短期対応を行う。

## 変更内容
- `ImageProcessable` に上限値 `MAX_IMAGE_SIZE` とサイズ判定メソッド `image_size_valid?` を定義する
- `Users::RegistrationsController#update` で、画像処理（リサイズ・変換）を行う前に元ファイルのサイズをチェックし、上限超過時は処理を中断してエラーを表示する
