### PR TITLE
色マス記憶のスコアを1問ごとではなくゲーム終了時に1回だけ保存するよう修正

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -46,8 +46,9 @@ class GamesController < ApplicationController
     else
       @score     = session[:score] || 0
       @game_type = GameType.find_by(name: session[:game_type])
-      save_score if user_signed_in?
     end
+
+    save_score if user_signed_in?
   end
 
   def color_grid
@@ -63,18 +64,10 @@ class GamesController < ApplicationController
 
 
   def color_grid_complete
-    game_type    = GameType.find_by!(name: "color_grid")
     target_count = [ [ params[:target_count].to_i, 3 ].max, 5 ].min
 
     result = ColorGridGenerator.generate(target_count: target_count)
 
-    if user_signed_in?
-      current_user.scores.create!(
-        game_type: game_type,
-        score:     params[:score].to_i,
-        played_on: Time.current.in_time_zone("Tokyo").to_date
-      )
-    end
 
     render json: {
       score:       params[:score].to_i,
@@ -86,10 +79,9 @@ class GamesController < ApplicationController
   private
 
   def save_score
-    game_type = GameType.find_by!(name: session[:game_type])
     Score.create!(
       user: current_user,
-      game_type: game_type,
+      game_type: @game_type,
       score: @score,
       played_on: Time.current.in_time_zone("Tokyo").to_date
     )

--- a/spec/requests/games_spec.rb
+++ b/spec/requests/games_spec.rb
@@ -81,16 +81,17 @@ RSpec.describe "Games", type: :request do
   end
 
   describe "POST /games/color_grid_complete" do
-    it "スコアが保存されJSONを返す" do
+    it "スコアを保存せず、次の問題のJSONを返す" do
       user = create(:user)
       sign_in user
       create(:game_type, name: "color_grid")
 
-      post color_grid_complete_games_path,
-        params: { score: 3, target_count: 3 }, as: :json
+      expect {
+        post color_grid_complete_games_path,
+          params: { score: 3, target_count: 3 }, as: :json
+      }.not_to change(Score, :count)
 
       expect(response).to have_http_status(:ok)
-      expect(Score.count).to eq(1)
       json = JSON.parse(response.body)
       expect(json).to have_key("next_sample")
       expect(json).to have_key("next_answer")


### PR DESCRIPTION
## 概要
色マス記憶で、スコアが1問正解ごとに記録されるバグを修正する。

## 背景
グラフの表示異常を調査したところ、`color_grid_complete`（1問完了ごとにフロントから呼ばれる）内で `scores.create!` しており、1ゲームで複数のスコアが記録されていた。他ゲームは終了時に1回だけ保存する設計になっており、色マス記憶だけ保存タイミングが異なっていた。

## 変更内容
- `color_grid_complete` からスコア保存処理を削除し、次の問題を返す役割のみとする
- `save_score` を `session` 依存から `@game_type` を使う形に変更し、全ゲーム共通で使えるようにする
- `result` アクションで、全ゲーム共通で終了時に1回だけ `save_score` を呼ぶよう修正する
- 上記の仕様変更に合わせて、`color_grid_complete` のテストを「スコアを保存しない」ことを検証する形に更新する